### PR TITLE
Document module: fix model property ordering

### DIFF
--- a/src/app/models/__init__.py
+++ b/src/app/models/__init__.py
@@ -2,3 +2,4 @@ from .post import Post
 from .rate_limit import RateLimit
 from .tier import Tier
 from .user import User
+from .document import Document

--- a/src/app/models/document.py
+++ b/src/app/models/document.py
@@ -14,7 +14,6 @@ def now():
 class Document(Base):
     __tablename__ = "document"
 
-    # Keys
     id: Mapped[int] = mapped_column(
         "id",
         autoincrement=True,
@@ -23,6 +22,12 @@ class Document(Base):
         primary_key=True,
         init=False,
     )
+    fname_external: Mapped[str] = mapped_column(
+        String(512),
+        nullable=False,
+    )
+    object_store_url: Mapped[str] = mapped_column(String(2083))
+
     owner: Mapped[int] = mapped_column(
         ForeignKey("user.id"),  # XXX Does user correspond to client-project?
         index=True,
@@ -30,19 +35,12 @@ class Document(Base):
         init=False,
     )
 
-    # Data representation
     fname_internal: Mapped[UUID] = mapped_column(
         index=True,
         unique=True,
         default_factory=uuid4,
     )
-    fname_external: Mapped[str] = mapped_column(
-        String(512),
-        nullable=False,
-    )
-    object_store_url: Mapped[str] = mapped_column(String(2083))
 
-    # Record management
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default_factory=now,


### PR DESCRIPTION
## Summary

Target issue is #40   

Although the document module was in the codebase, it was not being correctly imported. When updating the code to correctly import it, bad ordering of the property definitions prevents the server from starting.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `poetry run uvicorn src.app.main:app --reload` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

N/A
