### PR TITLE
Feature: convert SQLAlchemy model to engine-specific SQL

### DIFF
--- a/src/app/api/v1/__init__.py
+++ b/src/app/api/v1/__init__.py
@@ -8,6 +8,7 @@ from .tasks import router as tasks_router
 from .tiers import router as tiers_router
 from .users import router as users_router
 from .ai_assistant import router as ai_router
+from .data_defn_langs import router as ddl_router
 
 router = APIRouter(prefix="/v1")
 router.include_router(login_router)
@@ -18,3 +19,4 @@ router.include_router(tasks_router)
 router.include_router(tiers_router)
 router.include_router(rate_limits_router)
 router.include_router(ai_router)
+router.include_router(ddl_router)

--- a/src/app/api/v1/data_defn_langs.py
+++ b/src/app/api/v1/data_defn_langs.py
@@ -1,5 +1,3 @@
-from io import StringIO
-
 from fastapi import APIRouter
 from pydantic import BaseModel
 from sqlalchemy import create_engine

--- a/src/app/api/v1/data_defn_langs.py
+++ b/src/app/api/v1/data_defn_langs.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+
+router = APIRouter(tags=['ddls'])
+
+@router.get('/ddl/{model}')
+async def get_ddl(model: str) -> dict:
+    return {
+        'hello': model,
+    }

--- a/src/app/api/v1/data_defn_langs.py
+++ b/src/app/api/v1/data_defn_langs.py
@@ -1,9 +1,53 @@
+from io import StringIO
+
 from fastapi import APIRouter
+from sqlalchemy import create_engine
+from sqlalchemy.schema import CreateTable
+
+from ...models import (
+    Post,
+    RateLimit,
+    Tier,
+    User,
+)
+from ...core.db.database import async_engine
+from ...core.exceptions.http_exceptions import NotFoundException
 
 router = APIRouter(tags=['ddls'])
 
+class AlchemyCompiler:
+    _models = {
+        'post': Post,
+        'rate-limit': RateLimit,
+        'tier': Tier,
+        'user': User,
+    }
+
+    def __init__(self, model, engine):
+        self.model = model
+        self.engine = engine
+
+    def __str__(self):
+        return ';\n'.join(self)
+
+    def __iter__(self):
+        if self.model not in self._models:
+            raise NotFoundException(f'Model "{self.model}" not found')
+        yield from map(str, self._compile())
+
+    def _compile(self):
+        base = self._models.get(self.model)
+        for table in base.metadata.sorted_tables:
+            create = CreateTable(table)
+            yield create.compile(self.engine)
+
 @router.get('/ddl/{model}')
 async def get_ddl(model: str) -> dict:
+    engine = create_engine(async_engine.url)
+    compiler = AlchemyCompiler(model, engine)
+
     return {
-        'hello': model,
+        'model': model,
+        'engine': async_engine.url.drivername,
+        'schema':str(compiler),
     }

--- a/src/app/api/v1/data_defn_langs.py
+++ b/src/app/api/v1/data_defn_langs.py
@@ -1,6 +1,7 @@
 from io import StringIO
 
 from fastapi import APIRouter
+from pydantic import BaseModel
 from sqlalchemy import create_engine
 from sqlalchemy.schema import CreateTable
 
@@ -14,6 +15,11 @@ from ...core.db.database import async_engine
 from ...core.exceptions.http_exceptions import NotFoundException
 
 router = APIRouter(tags=['ddls'])
+
+class DatabaseDefinition(BaseModel):
+    model: str
+    engine: str
+    sql: str
 
 class AlchemyCompiler:
     _models = {
@@ -41,13 +47,13 @@ class AlchemyCompiler:
             create = CreateTable(table)
             yield create.compile(self.engine)
 
-@router.get('/ddl/{model}')
-async def get_ddl(model: str) -> dict:
+@router.get('/ddl/{model}', response_model=DatabaseDefinition)
+async def get_ddl_single(model: str) -> DatabaseDefinition:
     engine = create_engine(async_engine.url)
     compiler = AlchemyCompiler(model, engine)
 
-    return {
-        'model': model,
-        'engine': async_engine.url.drivername,
-        'schema':str(compiler),
-    }
+    return DatabaseDefinition(
+        model=model,
+        engine=async_engine.url.drivername,
+        sql=str(compiler),
+    )


### PR DESCRIPTION
## Summary

Target issue is #44

This PR alleviates the need to generate model SQL manually.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `poetry run uvicorn src.app.main:app --reload` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

This implementation uses an endpoint to specify the desired model, then returns the SQL schema in the HTTP response. In production, this may exposes our information publicly unless the endpoint is hidden behind some credentials. Another approach would be to add this functionality to `src/scripts`, outside the FastAPI ecosystem; but then it's unclear how to handle framework imports correctly.

If being an endpoint, or being an endpoint on master, is not appropriate please use this PR to discuss alternatives.