### PR TITLE
Refactor Onboarding Endpoint to Make User Context Optional

### DIFF
--- a/backend/app/api/routes/onboarding.py
+++ b/backend/app/api/routes/onboarding.py
@@ -51,7 +51,7 @@ class OnboardingRequest(BaseModel):
         return v
 
     @staticmethod
-    def _refactor_username(raw: str, max_len: int = 200) -> str:
+    def _clean_username(raw: str, max_len: int = 200) -> str:
         """
         Normalize a string into a safe username that can also be used
         as the local part of an email address.
@@ -64,10 +64,10 @@ class OnboardingRequest(BaseModel):
     @model_validator(mode="after")
     def set_defaults(self):
         if self.user_name is None:
-            self.user_name = self._refactor_username(self.project_name)
+            self.user_name = self._clean_username(self.project_name)
 
         if self.email is None:
-            local_part = self._refactor_username(self.user_name, max_len=200)
+            local_part = self._clean_username(self.user_name, max_len=200)
             suffix = secrets.token_hex(3)
             self.email = f"{local_part}.{suffix}@kaapi.org"
 

--- a/backend/app/api/routes/onboarding.py
+++ b/backend/app/api/routes/onboarding.py
@@ -37,19 +37,6 @@ class OnboardingRequest(BaseModel):
     password: str | None = None
     user_name: str | None = None
 
-    @field_validator("user_name")
-    def validate_username(cls, v):
-        if v is None:
-            return v
-
-        pattern = r"^[A-Za-z][A-Za-z0-9._]{2,199}$"
-        if not re.match(pattern, v):
-            raise ValueError(
-                "Username must start with a letter, can contain letters, numbers, underscores, and dots, "
-                "and must be between 3 and 200 characters long."
-            )
-        return v
-
     @staticmethod
     def _clean_username(raw: str, max_len: int = 200) -> str:
         """
@@ -64,7 +51,7 @@ class OnboardingRequest(BaseModel):
     @model_validator(mode="after")
     def set_defaults(self):
         if self.user_name is None:
-            self.user_name = self._clean_username(self.project_name)
+            self.user_name = self.project_name + " User"
 
         if self.email is None:
             local_part = self._clean_username(self.user_name, max_len=200)

--- a/backend/app/api/routes/onboarding.py
+++ b/backend/app/api/routes/onboarding.py
@@ -51,7 +51,8 @@ class OnboardingRequest(BaseModel):
     def set_defaults(self):
         # Generate email and password if missing
         if self.email is None:
-            self.email = f"{self.user_name}@kaapi.org"
+            suffix = secrets.token_hex(3)
+            self.email = f"{self.user_name}.{suffix}@kaapi.org"
 
         if self.password is None:
             self.password = secrets.token_urlsafe(8)

--- a/backend/app/tests/api/routes/test_onboarding.py
+++ b/backend/app/tests/api/routes/test_onboarding.py
@@ -19,7 +19,7 @@ def test_onboard_user(client, db: Session, superuser_token_headers: dict[str, st
         "project_name": "TestProject",
         "email": random_email(),
         "password": "testpassword123",
-        "user_name": "Test User",
+        "user_name": "test_user",
     }
 
     response = client.post(
@@ -65,7 +65,7 @@ def test_create_user_existing_email(
         "project_name": "TestProject",
         "email": random_email(),
         "password": "testpassword123",
-        "user_name": "Test User",
+        "user_name": "test_user",
     }
 
     client.post(
@@ -89,7 +89,7 @@ def test_is_superuser_flag(
         "project_name": "TestProjects",
         "email": random_email(),
         "password": "testpassword123",
-        "user_name": "Test User",
+        "user_name": "test_user",
     }
 
     response = client.post(
@@ -112,7 +112,7 @@ def test_organization_and_project_creation(
         "project_name": "NewProject",
         "email": random_email(),
         "password": "newpassword123",
-        "user_name": "New User",
+        "user_name": "new_user",
     }
 
     response = client.post(


### PR DESCRIPTION
## Summary

As we discussed for the Glific use case, we can make email optional in the onboarding flow.
This change simplifies onboarding and removes the need for clients to always provide an email address.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding can create accounts without email, password, or username — the system auto-generates a secure password and a kaapi.org email, and derives a default display name when omitted.
  * Usernames are normalized and validated (starts with a letter; letters/digits/underscore/dot allowed; length limits) to produce safe identifiers for accounts.

* **Tests**
  * Onboarding tests updated to use snake_case usernames to reflect the normalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->