### PR TITLE
OpenAI Assistant: Allow temperature to be 0

### DIFF
--- a/backend/app/crud/assistants.py
+++ b/backend/app/crud/assistants.py
@@ -106,7 +106,6 @@ def sync_assistant(
     Insert an assistant into the database by converting OpenAI Assistant to local Assistant model.
     """
     assistant_id = openai_assistant.id
-
     existing_assistant = get_assistant_by_id(session, assistant_id, project_id)
     if existing_assistant:
         logger.warning(
@@ -148,7 +147,9 @@ def sync_assistant(
         instructions=openai_assistant.instructions,
         model=openai_assistant.model,
         vector_store_ids=vector_store_ids,
-        temperature=openai_assistant.temperature or 0.1,
+        temperature=openai_assistant.temperature
+        if openai_assistant.temperature is not None
+        else 0,
         max_num_results=max_num_results,
         project_id=project_id,
         organization_id=organization_id,

--- a/backend/app/models/assistants.py
+++ b/backend/app/models/assistants.py
@@ -66,7 +66,7 @@ class AssistantCreate(SQLModel):
         description="List of Vector Store IDs that exist in OpenAI.",
     )
     temperature: float = Field(
-        default=0.1, gt=0, le=2, description="Sampling temperature between 0 and 2"
+        default=0.1, ge=0, le=2, description="Sampling temperature between 0 and 2"
     )
     max_num_results: int = Field(
         default=20,
@@ -91,7 +91,7 @@ class AssistantUpdate(SQLModel):
     vector_store_ids_add: list[str] | None = None
     vector_store_ids_remove: list[str] | None = None
     temperature: float | None = Field(
-        default=None, gt=0, le=2, description="Sampling temperature between 0 and 2"
+        default=None, ge=0, le=2, description="Sampling temperature between 0 and 2"
     )
     max_num_results: int | None = Field(
         default=None,


### PR DESCRIPTION
## Summary
Previously, the temperature field validation prevented setting temperature to 0, which is a valid value for openai assistant. The sync logic also incorrectly treated 0 as a falsy value and defaulted to 0.1.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Setting assistant temperature to 0 is now fully supported and retained during creation and updates.
  * Explicit 0 values are no longer overridden by a default; a default is applied only when temperature is not provided.
  * Validation now accepts 0 (range: 0 to 2), preventing errors when submitting 0 via UI or API.
  * Improves consistency and predictability of assistant behavior at low/zero temperature settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->