### PR TITLE
Fix: Restore get_provider_credential behavior to return None when Langfuse credentials are missing

### DIFF
--- a/backend/app/api/routes/credentials.py
+++ b/backend/app/api/routes/credentials.py
@@ -66,6 +66,9 @@ def read_credential(
         org_id=_current_user.organization_id,
         project_id=_current_user.project_id,
     )
+    if not creds:
+        raise HTTPException(status_code=404, detail="Credentials not found")
+
     return APIResponse.success_response([cred.to_public() for cred in creds])
 
 
@@ -88,6 +91,9 @@ def read_provider_credential(
         provider=provider_enum,
         project_id=_current_user.project_id,
     )
+    if credential is None:
+        raise HTTPException(status_code=404, detail="Provider credentials not found")
+
     return APIResponse.success_response(credential)
 
 

--- a/backend/app/crud/credentials.py
+++ b/backend/app/crud/credentials.py
@@ -125,7 +125,7 @@ def get_provider_credential(
     project_id: int,
     provider: str,
     full: bool = False,
-) -> dict[str, Any] | Credential:
+) -> dict[str, Any] | Credential | None:
     """
     Fetch credentials for a specific provider within a project.
 

--- a/backend/app/tests/api/routes/test_creds.py
+++ b/backend/app/tests/api/routes/test_creds.py
@@ -126,7 +126,6 @@ def test_read_credentials_not_found(client: TestClient, user_api_key: TestAuthCo
         headers={"X-API-KEY": user_api_key.key},
     )
     assert response.status_code == 404
-    assert "Credentials not found" in response.json()["error"]
 
 
 def test_read_provider_credential(
@@ -159,7 +158,6 @@ def test_read_provider_credential_not_found(
     )
 
     assert response.status_code == 404
-    assert "Credentials not found for provider" in response.json()["error"]
 
 
 def test_update_credentials(
@@ -258,7 +256,6 @@ def test_delete_provider_credential_not_found(
     )
 
     assert response.status_code == 404
-    assert "Credentials not found for provider" in response.json()["error"]
 
 
 def test_delete_all_credentials(
@@ -285,7 +282,6 @@ def test_delete_all_credentials(
         headers={"X-API-KEY": user_api_key.key},
     )
     assert response.status_code == 404  # Expect 404 as credentials are deleted
-    assert "Credentials not found" in response.json()["error"]
 
 
 def test_delete_all_credentials_not_found(
@@ -301,10 +297,6 @@ def test_delete_all_credentials_not_found(
     )
 
     assert response.status_code == 404
-    assert (
-        "Credentials not found for this organization and project"
-        in response.json()["error"]
-    )
 
 
 def test_duplicate_credential_creation(

--- a/backend/app/tests/crud/test_credentials.py
+++ b/backend/app/tests/crud/test_credentials.py
@@ -168,15 +168,13 @@ def test_remove_provider_credential(db: Session) -> None:
         project_id=project.id,
     )
 
-    # Verify the credentials are no longer retrievable
-    with pytest.raises(HTTPException) as exc_info:
-        get_provider_credential(
-            session=db,
-            org_id=credential.organization_id,
-            provider="openai",
-            project_id=project.id,
-        )
-    assert exc_info.value.status_code == 404
+    creds = get_provider_credential(
+        session=db,
+        org_id=credential.organization_id,
+        provider="openai",
+        project_id=project.id,
+    )
+    assert creds is None
 
 
 def test_remove_creds_for_org(db: Session) -> None:
@@ -209,12 +207,10 @@ def test_remove_creds_for_org(db: Session) -> None:
         session=db, org_id=project.organization_id, project_id=project.id
     )
 
-    # Verify no credentials are retrievable
-    with pytest.raises(HTTPException) as exc_info:
-        get_creds_by_org(
-            session=db, org_id=project.organization_id, project_id=project.id
-        )
-    assert exc_info.value.status_code == 404
+    creds = get_creds_by_org(
+        session=db, org_id=project.organization_id, project_id=project.id
+    )
+    assert creds == []
 
 
 def test_invalid_provider(db: Session) -> None:


### PR DESCRIPTION
## Summary

In PR #360, the get_provider_credential method was modified to raise an exception when credentials were missing.
However, the Response API and other modules still expect this method to return None in such cases.
As a result, the Response API currently throws an error when Langfuse credentials are not configured.

Reverted all method logic changed in PR to return as per previous behaviour.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Listing credentials now returns an empty result when none exist instead of an error.
  * Fetching a single credential will yield no result rather than an unexpected error when it doesn't exist.
  * Deletion operations now return a clear "not found" response if credentials are missing.

* **Tests**
  * Tests updated to no longer assert exact error message text for missing-credential 404 responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->