### PR TITLE
Integrate Config Management with Unified Api

### DIFF
--- a/backend/app/crud/config/config.py
+++ b/backend/app/crud/config/config.py
@@ -47,7 +47,7 @@ class ConfigCrud:
             version = ConfigVersion(
                 config_id=config.id,
                 version=1,
-                config_blob=config_create.config_blob,
+                config_blob=config_create.config_blob.model_dump(),
                 commit_message=config_create.commit_message,
             )
 

--- a/backend/app/crud/config/version.py
+++ b/backend/app/crud/config/version.py
@@ -34,7 +34,7 @@ class ConfigVersionCrud:
             version = ConfigVersion(
                 config_id=self.config_id,
                 version=next_version,
-                config_blob=version_create.config_blob,
+                config_blob=version_create.config_blob.model_dump(),
                 commit_message=version_create.commit_message,
             )
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -87,6 +87,8 @@ from .fine_tuning import (
 from .job import Job, JobType, JobStatus, JobUpdate
 
 from .llm import (
+    ConfigBlob,
+    CompletionConfig,
     LLMCallRequest,
     LLMCallResponse,
 )

--- a/backend/app/models/config/config.py
+++ b/backend/app/models/config/config.py
@@ -2,10 +2,11 @@ from uuid import UUID, uuid4
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from sqlmodel import Field, SQLModel, UniqueConstraint, Index, text
+from sqlmodel import Field, SQLModel, Index, text
 from pydantic import field_validator
 
 from app.core.util import now
+from app.models.llm.request import ConfigBlob
 from .version import ConfigVersionPublic
 
 
@@ -56,7 +57,7 @@ class ConfigCreate(ConfigBase):
     """Create new configuration"""
 
     # Initial version data
-    config_blob: dict[str, Any] = Field(description="Provider-specific parameters")
+    config_blob: ConfigBlob = Field(description="Provider-specific parameters")
     commit_message: str | None = Field(
         default=None,
         max_length=512,

--- a/backend/app/models/config/version.py
+++ b/backend/app/models/config/version.py
@@ -8,6 +8,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, SQLModel, UniqueConstraint, Index, text
 
 from app.core.util import now
+from app.models.llm.request import ConfigBlob
 
 
 class ConfigVersionBase(SQLModel):
@@ -60,7 +61,12 @@ class ConfigVersion(ConfigVersionBase, table=True):
 
 
 class ConfigVersionCreate(ConfigVersionBase):
-    pass
+    # Store config_blob as JSON in the DB. Validation uses ConfigBlob only at creation
+    # time, since schema may evolve. When fetching, it is returned as a raw dict and
+    # re-validated against the latest schema before use.
+    config_blob: ConfigBlob = Field(
+        description="Provider-specific configuration parameters (temperature, max_tokens, etc.)",
+    )
 
 
 class ConfigVersionPublic(ConfigVersionBase):

--- a/backend/app/models/llm/__init__.py
+++ b/backend/app/models/llm/__init__.py
@@ -1,2 +1,7 @@
-from app.models.llm.request import LLMCallRequest, CompletionConfig, QueryParams, ConfigBlob
+from app.models.llm.request import (
+    LLMCallRequest,
+    CompletionConfig,
+    QueryParams,
+    ConfigBlob,
+)
 from app.models.llm.response import LLMCallResponse, LLMResponse, LLMOutput, Usage

--- a/backend/app/models/llm/__init__.py
+++ b/backend/app/models/llm/__init__.py
@@ -1,2 +1,2 @@
-from app.models.llm.request import LLMCallRequest, CompletionConfig, QueryParams
+from app.models.llm.request import LLMCallRequest, CompletionConfig, QueryParams, ConfigBlob
 from app.models.llm.response import LLMCallResponse, LLMResponse, LLMOutput, Usage

--- a/backend/app/models/llm/request.py
+++ b/backend/app/models/llm/request.py
@@ -130,7 +130,14 @@ class LLMCallRequest(SQLModel):
     """User-facing API request for LLM completion."""
 
     query: QueryParams = Field(..., description="Query-specific parameters")
-    config: LLMCallConfig = Field(..., description="Configuration for the LLM call")
+    config: LLMCallConfig = Field(
+        ...,
+        description=(
+            "Complete LLM call configuration, provided either by reference (id + version) "
+            "or as config blob. Use the blob only for testing/validation; "
+            "in production, always use the id + version."
+        ),
+    )
     callback_url: HttpUrl | None = Field(
         default=None, description="Webhook URL for async response delivery"
     )

--- a/backend/app/models/llm/request.py
+++ b/backend/app/models/llm/request.py
@@ -127,7 +127,15 @@ class LLMCallConfig(SQLModel):
 
 
 class LLMCallRequest(SQLModel):
-    """User-facing API request for LLM completion."""
+    """
+    API request for an LLM completion.
+
+    The `config` field accepts either:
+    - **Stored config (id + version)** — recommended for all production use.
+    - **Inline config blob** — for testing or validating new configs.
+
+    Prefer stored configs in production; use blobs only for development/testing/validations.
+    """
 
     query: QueryParams = Field(..., description="Query-specific parameters")
     config: LLMCallConfig = Field(

--- a/backend/app/models/llm/request.py
+++ b/backend/app/models/llm/request.py
@@ -1,5 +1,6 @@
 from typing import Any, Literal
 
+from uuid import UUID
 from sqlmodel import Field, SQLModel
 from pydantic import model_validator, HttpUrl
 
@@ -57,13 +58,72 @@ class CompletionConfig(SQLModel):
     )
 
 
-class LLMCallConfig(SQLModel):
-    """Complete configuration for LLM call including all processing stages."""
+class ConfigBlob(SQLModel):
+    """Raw JSON blob of config."""
 
     completion: CompletionConfig = Field(..., description="Completion configuration")
     # Future additions:
     # classifier: ClassifierConfig | None = None
     # pre_filter: PreFilterConfig | None = None
+
+
+class LLMCallConfig(SQLModel):
+    """
+    Complete configuration for LLM call including all processing stages.
+    Either references a stored config (id + version) or provides an ad-hoc config blob.
+    Depending on which is provided, only one of the two options should be used.
+    """
+
+    id: UUID | None = Field(
+        default=None,
+        description=(
+            "Identifier for an existing LLM call configuration. [require version if provided]"
+        ),
+    )
+    version: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Version of the stored config to use. [require if id is provided]"
+        ),
+    )
+
+    blob: ConfigBlob | None = Field(
+        default=None,
+        description=(
+            "Raw JSON blob of the full configuration. Used for ad-hoc configurations without storing."
+            "Either this or (id + version) must be provided."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_config_logic(self):
+        has_stored = self.id is not None or self.version is not None
+        has_blob = self.blob is not None
+
+        if has_stored and has_blob:
+            raise ValueError(
+                "Provide either 'id' with 'version' for stored config OR 'blob' for ad-hoc config, not both."
+            )
+
+        if has_stored:
+            if not self.id or not self.version:
+                raise ValueError(
+                    "'id' and 'version' must both be provided together for stored config."
+                )
+            return self
+
+        if not has_blob:
+            raise ValueError(
+                "Must provide either a stored config (id + version) or an ad-hoc config (blob)."
+            )
+
+        return self
+
+    @property
+    def is_stored_config(self) -> bool:
+        """Check if the config refers to a stored config or not."""
+        return self.id is not None and self.version is not None
 
 
 class LLMCallRequest(SQLModel):

--- a/backend/app/services/llm/jobs.py
+++ b/backend/app/services/llm/jobs.py
@@ -161,26 +161,26 @@ def execute_job(
                         error=error,
                         metadata=request.request_metadata,
                     )
+                    return handle_job_error(
+                        job_id, request.callback_url, callback_response
+                    )
 
             else:
                 config_blob = config.blob
 
-            if callback_response is None:
-                try:
-                    provider_instance = get_llm_provider(
-                        session=session,
-                        provider_type=config_blob.completion.provider,
-                        project_id=project_id,
-                        organization_id=organization_id,
-                    )
-                except ValueError as ve:
-                    callback_response = APIResponse.failure_response(
-                        error=str(ve),
-                        metadata=request.request_metadata,
-                    )
-
-        if callback_response:
-            return handle_job_error(job_id, request.callback_url, callback_response)
+            try:
+                provider_instance = get_llm_provider(
+                    session=session,
+                    provider_type=config_blob.completion.provider,
+                    project_id=project_id,
+                    organization_id=organization_id,
+                )
+            except ValueError as ve:
+                callback_response = APIResponse.failure_response(
+                    error=str(ve),
+                    metadata=request.request_metadata,
+                )
+                return handle_job_error(job_id, request.callback_url, callback_response)
 
         response, error = provider_instance.execute(
             completion_config=config_blob.completion,

--- a/backend/app/services/llm/jobs.py
+++ b/backend/app/services/llm/jobs.py
@@ -89,7 +89,7 @@ def resolve_config_blob(
         - error_message: human-safe error string if an error occurs, else None
     """
     try:
-        config_version = config_crud.read_one(version_number=config.version)
+        config_version = config_crud.exists_or_raise(version_number=config.version)
     except HTTPException as e:
         return None, f"Failed to retrieve stored configuration: {e.detail}"
     except Exception:
@@ -99,11 +99,6 @@ def resolve_config_blob(
             exc_info=True,
         )
         return None, "Unexpected error occurred while retrieving stored configuration"
-
-    if not config_version:
-        return None, (
-            f"Configuration version {config.version} not found for config ID {config.id}"
-        )
 
     try:
         return ConfigBlob(**config_version.config_blob), None

--- a/backend/app/services/llm/jobs.py
+++ b/backend/app/services/llm/jobs.py
@@ -6,8 +6,10 @@ from fastapi import HTTPException
 from sqlmodel import Session
 
 from app.core.db import engine
+from app.crud.config import ConfigVersionCrud
 from app.crud.jobs import JobCrud
-from app.models import JobStatus, JobType, JobUpdate, LLMCallRequest, LLMCallResponse
+from app.models import JobStatus, JobType, JobUpdate, LLMCallRequest
+from app.models.llm.request import ConfigBlob, LLMCallConfig
 from app.utils import APIResponse, send_callback
 from app.celery.utils import start_high_priority_job
 from app.services.llm.providers.registry import get_llm_provider
@@ -76,6 +78,46 @@ def handle_job_error(
     return callback_response.model_dump()
 
 
+def resolve_config_blob(
+    config_crud: ConfigVersionCrud, config: LLMCallConfig
+) -> tuple[ConfigBlob | None, str | None]:
+    """Fetch and parse stored config version into ConfigBlob.
+
+    Returns:
+        (config_blob, error_message)
+        - config_blob: ConfigBlob if successful, else None
+        - error_message: human-safe error string if an error occurs, else None
+    """
+    try:
+        config_version = config_crud.read_one(version_number=config.version)
+    except HTTPException as e:
+        return None, f"Failed to retrieve stored configuration: {e.detail}"
+    except Exception:
+        logger.error(
+            f"[resolve_config_blob] Unexpected error retrieving config version | "
+            f"config_id={config.id}, version={config.version}",
+            exc_info=True,
+        )
+        return None, "Unexpected error occurred while retrieving stored configuration"
+
+    if not config_version:
+        return None, (
+            f"Configuration version {config.version} not found for config ID {config.id}"
+        )
+
+    try:
+        return ConfigBlob(**config_version.config_blob), None
+    except (TypeError, ValueError) as e:
+        return None, f"Stored configuration blob is invalid: {str(e)}"
+    except Exception:
+        logger.error(
+            f"[resolve_config_blob] Unexpected error parsing config blob | "
+            f"config_id={config.id}, version={config.version}",
+            exc_info=True,
+        )
+        return None, "Unexpected error occurred while parsing stored configuration"
+
+
 def execute_job(
     request_data: dict,
     project_id: int,
@@ -93,41 +135,60 @@ def execute_job(
     request = LLMCallRequest(**request_data)
     job_id: UUID = UUID(job_id)
 
+    # one of (id, version) or blob is guaranteed to be present due to prior validation
     config = request.config
-    provider = config.completion.provider
     callback = None
+    config_blob: ConfigBlob | None = None
 
     logger.info(
         f"[execute_job] Starting LLM job execution | job_id={job_id}, task_id={task_id}, "
-        f"provider={provider}"
     )
 
     try:
-        # Update job status to PROCESSING
         with Session(engine) as session:
+            # Update job status to PROCESSING
             job_crud = JobCrud(session=session)
             job_crud.update(
                 job_id=job_id, job_update=JobUpdate(status=JobStatus.PROCESSING)
             )
 
-            try:
-                provider_instance = get_llm_provider(
-                    session=session,
-                    provider_type=provider,
-                    project_id=project_id,
-                    organization_id=organization_id,
+            # if stored config, fetch blob from DB
+            if config.is_stored_config:
+                config_crud = ConfigVersionCrud(
+                    session=session, project_id=project_id, config_id=config.id
                 )
-            except ValueError as ve:
-                callback = APIResponse.failure_response(
-                    error=str(ve),
-                    metadata=request.request_metadata,
-                )
+
+                # blob is dynamic, need to resolve to ConfigBlob format
+                config_blob, error = resolve_config_blob(config_crud, config)
+
+                if error:
+                    callback = APIResponse.failure_response(
+                        error=error,
+                        metadata=request.request_metadata,
+                    )
+
+            else:
+                config_blob = config.blob
+
+            if callback is None:
+                try:
+                    provider_instance = get_llm_provider(
+                        session=session,
+                        provider_type=config_blob.completion.provider,
+                        project_id=project_id,
+                        organization_id=organization_id,
+                    )
+                except ValueError as ve:
+                    callback = APIResponse.failure_response(
+                        error=str(ve),
+                        metadata=request.request_metadata,
+                    )
 
         if callback:
             return handle_job_error(job_id, request.callback_url, callback)
 
         response, error = provider_instance.execute(
-            completion_config=config.completion,
+            completion_config=config_blob.completion,
             query=request.query,
             include_provider_raw_response=request.include_provider_raw_response,
         )

--- a/backend/app/services/llm/jobs.py
+++ b/backend/app/services/llm/jobs.py
@@ -222,7 +222,7 @@ def execute_job(
             metadata=request.request_metadata,
         )
         logger.error(
-            f"[execute_job] {callback_response.error} {str(e)} | job_id={job_id}, task_id={task_id}",
+            f"[execute_job] Unknown error occurred: {str(e)} | job_id={job_id}, task_id={task_id}",
             exc_info=True,
         )
         return handle_job_error(job_id, request.callback_url, callback_response)

--- a/backend/app/tests/api/routes/configs/test_config.py
+++ b/backend/app/tests/api/routes/configs/test_config.py
@@ -18,9 +18,14 @@ def test_create_config_success(
         "name": "test-llm-config",
         "description": "A test LLM configuration",
         "config_blob": {
-            "model": "gpt-4",
-            "temperature": 0.8,
-            "max_tokens": 2000,
+            "completion": {
+                "provider": "openai",
+                "params": {
+                    "model": "gpt-4",
+                    "temperature": 0.8,
+                    "max_tokens": 2000,
+                },
+            }
         },
         "commit_message": "Initial configuration",
     }
@@ -81,7 +86,12 @@ def test_create_config_duplicate_name_fails(
     config_data = {
         "name": "duplicate-config",
         "description": "Should fail",
-        "config_blob": {"model": "gpt-4"},
+        "config_blob": {
+            "completion": {
+                "provider": "openai",
+                "params": {"model": "gpt-4"},
+            }
+        },
         "commit_message": "Initial",
     }
 
@@ -406,7 +416,12 @@ def test_create_config_requires_authentication(
     config_data = {
         "name": "test-config",
         "description": "Test",
-        "config_blob": {"model": "gpt-4"},
+        "config_blob": {
+            "completion": {
+                "provider": "openai",
+                "params": {"model": "gpt-4"},
+            }
+        },
         "commit_message": "Initial",
     }
 

--- a/backend/app/tests/api/routes/configs/test_version.py
+++ b/backend/app/tests/api/routes/configs/test_version.py
@@ -26,9 +26,14 @@ def test_create_version_success(
 
     version_data = {
         "config_blob": {
-            "model": "gpt-4-turbo",
-            "temperature": 0.9,
-            "max_tokens": 3000,
+            "completion": {
+                "provider": "openai",
+                "params": {
+                    "model": "gpt-4-turbo",
+                    "temperature": 0.9,
+                    "max_tokens": 3000,
+                },
+            }
         },
         "commit_message": "Updated model to gpt-4-turbo",
     }
@@ -83,7 +88,12 @@ def test_create_version_nonexistent_config(
     """Test creating a version for a non-existent config returns 404."""
     fake_uuid = uuid4()
     version_data = {
-        "config_blob": {"model": "gpt-4"},
+        "config_blob": {
+            "completion": {
+                "provider": "openai",
+                "params": {"model": "gpt-4"},
+            }
+        },
         "commit_message": "Test",
     }
 
@@ -109,7 +119,12 @@ def test_create_version_different_project_fails(
     )
 
     version_data = {
-        "config_blob": {"model": "gpt-4"},
+        "config_blob": {
+            "completion": {
+                "provider": "openai",
+                "params": {"model": "gpt-4"},
+            }
+        },
         "commit_message": "Should fail",
     }
 
@@ -136,7 +151,12 @@ def test_create_version_auto_increments(
     # Create multiple versions and verify they increment
     for i in range(2, 5):
         version_data = {
-            "config_blob": {"model": f"gpt-4-version-{i}"},
+            "config_blob": {
+                "completion": {
+                    "provider": "openai",
+                    "params": {"model": f"gpt-4-version-{i}"},
+                }
+            },
             "commit_message": f"Version {i}",
         }
 
@@ -278,11 +298,18 @@ def test_get_version_by_number(
     )
 
     # Create additional version
+    from app.models.llm.request import ConfigBlob, CompletionConfig
+
     version = create_test_version(
         db=db,
         config_id=config.id,
         project_id=user_api_key.project_id,
-        config_blob={"model": "gpt-4-turbo", "temperature": 0.5},
+        config_blob=ConfigBlob(
+            completion=CompletionConfig(
+                provider="openai",
+                params={"model": "gpt-4-turbo", "temperature": 0.5},
+            )
+        ),
         commit_message="Updated config",
     )
 
@@ -421,7 +448,12 @@ def test_create_version_requires_authentication(
 ) -> None:
     """Test that creating a version without authentication fails."""
     version_data = {
-        "config_blob": {"model": "gpt-4"},
+        "config_blob": {
+            "completion": {
+                "provider": "openai",
+                "params": {"model": "gpt-4"},
+            }
+        },
         "commit_message": "Test",
     }
 

--- a/backend/app/tests/api/routes/configs/test_version.py
+++ b/backend/app/tests/api/routes/configs/test_version.py
@@ -10,6 +10,7 @@ from app.tests.utils.test_data import (
     create_test_project,
     create_test_version,
 )
+from app.models import ConfigBlob, CompletionConfig
 
 
 def test_create_version_success(
@@ -296,9 +297,6 @@ def test_get_version_by_number(
         project_id=user_api_key.project_id,
         name="test-config",
     )
-
-    # Create additional version
-    from app.models.llm.request import ConfigBlob, CompletionConfig
 
     version = create_test_version(
         db=db,

--- a/backend/app/tests/api/routes/test_llm.py
+++ b/backend/app/tests/api/routes/test_llm.py
@@ -1,7 +1,12 @@
 from unittest.mock import patch
 from fastapi.testclient import TestClient
 from app.models import LLMCallRequest
-from app.models.llm.request import QueryParams, LLMCallConfig, CompletionConfig
+from app.models.llm.request import (
+    QueryParams,
+    LLMCallConfig,
+    CompletionConfig,
+    ConfigBlob,
+)
 
 
 def test_llm_call_success(client: TestClient, user_api_key_header: dict[str, str]):
@@ -12,12 +17,14 @@ def test_llm_call_success(client: TestClient, user_api_key_header: dict[str, str
         payload = LLMCallRequest(
             query=QueryParams(input="What is the capital of France?"),
             config=LLMCallConfig(
-                completion=CompletionConfig(
-                    provider="openai",
-                    params={
-                        "model": "gpt-4",
-                        "temperature": 0.7,
-                    },
+                blob=ConfigBlob(
+                    completion=CompletionConfig(
+                        provider="openai",
+                        params={
+                            "model": "gpt-4",
+                            "temperature": 0.7,
+                        },
+                    )
                 )
             ),
             callback_url="https://example.com/callback",

--- a/backend/app/tests/crud/config/test_config.py
+++ b/backend/app/tests/crud/config/test_config.py
@@ -58,7 +58,9 @@ def test_create_config(db: Session, example_config_blob: ConfigBlob) -> None:
     assert version.commit_message == "Initial version"
 
 
-def test_create_config_duplicate_name(db: Session, example_config_blob: ConfigBlob) -> None:
+def test_create_config_duplicate_name(
+    db: Session, example_config_blob: ConfigBlob
+) -> None:
     """Test creating a configuration with a duplicate name raises HTTPException."""
     project = create_test_project(db)
     config_crud = ConfigCrud(session=db, project_id=project.id)
@@ -81,7 +83,9 @@ def test_create_config_duplicate_name(db: Session, example_config_blob: ConfigBl
         config_crud.create_or_raise(config_create)
 
 
-def test_create_config_different_projects_same_name(db: Session, example_config_blob: ConfigBlob) -> None:
+def test_create_config_different_projects_same_name(
+    db: Session, example_config_blob: ConfigBlob
+) -> None:
     """Test creating configs with same name in different projects succeeds."""
     project1 = create_test_project(db)
     project2 = create_test_project(db)

--- a/backend/app/tests/crud/config/test_config.py
+++ b/backend/app/tests/crud/config/test_config.py
@@ -5,6 +5,8 @@ from fastapi import HTTPException
 
 from app.models import (
     Config,
+    ConfigBlob,
+    CompletionConfig,
     ConfigCreate,
     ConfigUpdate,
 )
@@ -13,21 +15,30 @@ from app.tests.utils.test_data import create_test_project, create_test_config
 from app.tests.utils.utils import random_lower_string
 
 
-def test_create_config(db: Session) -> None:
+@pytest.fixture
+def example_config_blob():
+    return ConfigBlob(
+        completion=CompletionConfig(
+            provider="openai",
+            params={
+                "model": "gpt-4",
+                "temperature": 0.8,
+                "max_tokens": 1500,
+            },
+        )
+    )
+
+
+def test_create_config(db: Session, example_config_blob: ConfigBlob) -> None:
     """Test creating a new configuration with initial version."""
     project = create_test_project(db)
     config_crud = ConfigCrud(session=db, project_id=project.id)
 
     config_name = f"test-config-{random_lower_string()}"
-    config_blob = {
-        "model": "gpt-4",
-        "temperature": 0.7,
-        "max_tokens": 1000,
-    }
     config_create = ConfigCreate(
         name=config_name,
         description="Test configuration",
-        config_blob=config_blob,
+        config_blob=example_config_blob,
         commit_message="Initial version",
     )
 
@@ -43,11 +54,11 @@ def test_create_config(db: Session) -> None:
     assert version.id is not None
     assert version.config_id == config.id
     assert version.version == 1
-    assert version.config_blob == config_blob
+    assert version.config_blob == example_config_blob.model_dump()
     assert version.commit_message == "Initial version"
 
 
-def test_create_config_duplicate_name(db: Session) -> None:
+def test_create_config_duplicate_name(db: Session, example_config_blob: ConfigBlob) -> None:
     """Test creating a configuration with a duplicate name raises HTTPException."""
     project = create_test_project(db)
     config_crud = ConfigCrud(session=db, project_id=project.id)
@@ -56,7 +67,7 @@ def test_create_config_duplicate_name(db: Session) -> None:
     config_create = ConfigCreate(
         name=config_name,
         description="Test configuration",
-        config_blob={"model": "gpt-4"},
+        config_blob=example_config_blob,
         commit_message="Initial version",
     )
 
@@ -70,13 +81,13 @@ def test_create_config_duplicate_name(db: Session) -> None:
         config_crud.create_or_raise(config_create)
 
 
-def test_create_config_different_projects_same_name(db: Session) -> None:
+def test_create_config_different_projects_same_name(db: Session, example_config_blob: ConfigBlob) -> None:
     """Test creating configs with same name in different projects succeeds."""
     project1 = create_test_project(db)
     project2 = create_test_project(db)
 
     config_name = f"test-config-{random_lower_string()}"
-    config_blob = {"model": "gpt-4"}
+    config_blob = example_config_blob
 
     # Create config in project1
     config_crud1 = ConfigCrud(session=db, project_id=project1.id)

--- a/backend/app/tests/crud/config/test_version.py
+++ b/backend/app/tests/crud/config/test_version.py
@@ -11,6 +11,7 @@ from app.tests.utils.test_data import (
     create_test_version,
 )
 
+
 @pytest.fixture
 def example_config_blob():
     return ConfigBlob(
@@ -23,6 +24,7 @@ def example_config_blob():
             },
         )
     )
+
 
 def test_create_version(db: Session, example_config_blob: ConfigBlob) -> None:
     """Test creating a new version for an existing configuration."""
@@ -47,7 +49,9 @@ def test_create_version(db: Session, example_config_blob: ConfigBlob) -> None:
     assert version.deleted_at is None
 
 
-def test_create_version_auto_increment(db: Session, example_config_blob: ConfigBlob) -> None:
+def test_create_version_auto_increment(
+    db: Session, example_config_blob: ConfigBlob
+) -> None:
     """Test that version numbers auto-increment correctly."""
     config = create_test_config(db)
     version_crud = ConfigVersionCrud(
@@ -70,7 +74,9 @@ def test_create_version_auto_increment(db: Session, example_config_blob: ConfigB
     assert version4.version == 4
 
 
-def test_create_version_config_not_found(db: Session, example_config_blob: ConfigBlob) -> None:
+def test_create_version_config_not_found(
+    db: Session, example_config_blob: ConfigBlob
+) -> None:
     """Test creating a version for a non-existent config raises HTTPException."""
     project = create_test_project(db)
     non_existent_config_id = uuid4()
@@ -367,7 +373,9 @@ def test_exists_version_deleted(db: Session) -> None:
         version_crud.exists_or_raise(version.version)
 
 
-def test_create_version_different_configs(db: Session, example_config_blob: ConfigBlob) -> None:
+def test_create_version_different_configs(
+    db: Session, example_config_blob: ConfigBlob
+) -> None:
     """Test that version numbers are independent across different configs."""
     project = create_test_project(db)
 

--- a/backend/app/tests/utils/test_data.py
+++ b/backend/app/tests/utils/test_data.py
@@ -20,7 +20,7 @@ from app.models import (
     ConfigCreate,
     ConfigVersion,
     ConfigVersionCreate,
-    ConfigBase
+    ConfigBase,
 )
 from app.crud import (
     create_organization,

--- a/backend/app/tests/utils/test_data.py
+++ b/backend/app/tests/utils/test_data.py
@@ -8,6 +8,8 @@ from app.models import (
     Credential,
     OrganizationCreate,
     ProjectCreate,
+    ConfigBlob,
+    CompletionConfig,
     CredsCreate,
     FineTuningJobCreate,
     Fine_Tuning,
@@ -18,6 +20,7 @@ from app.models import (
     ConfigCreate,
     ConfigVersion,
     ConfigVersionCreate,
+    ConfigBase
 )
 from app.crud import (
     create_organization,
@@ -238,7 +241,7 @@ def create_test_config(
     project_id: int | None = None,
     name: str | None = None,
     description: str | None = None,
-    config_blob: dict | None = None,
+    config_blob: ConfigBlob | None = None,
 ) -> Config:
     """
     Creates and returns a test configuration with an initial version.
@@ -253,11 +256,16 @@ def create_test_config(
         name = f"test-config-{random_lower_string()}"
 
     if config_blob is None:
-        config_blob = {
-            "model": "gpt-4",
-            "temperature": 0.7,
-            "max_tokens": 1000,
-        }
+        config_blob = ConfigBlob(
+            completion=CompletionConfig(
+                provider="openai",
+                params={
+                    "model": "gpt-4",
+                    "temperature": 0.7,
+                    "max_tokens": 1000,
+                },
+            )
+        )
 
     config_create = ConfigCreate(
         name=name,
@@ -276,7 +284,7 @@ def create_test_version(
     db: Session,
     config_id,
     project_id: int,
-    config_blob: dict | None = None,
+    config_blob: ConfigBlob | None = None,
     commit_message: str | None = None,
 ) -> ConfigVersion:
     """
@@ -285,11 +293,16 @@ def create_test_version(
     Persists the version to the database.
     """
     if config_blob is None:
-        config_blob = {
-            "model": "gpt-4",
-            "temperature": 0.8,
-            "max_tokens": 1500,
-        }
+        config_blob = ConfigBlob(
+            completion=CompletionConfig(
+                provider="openai",
+                params={
+                    "model": "gpt-4",
+                    "temperature": 0.8,
+                    "max_tokens": 1500,
+                },
+            )
+        )
 
     version_create = ConfigVersionCreate(
         config_blob=config_blob,


### PR DESCRIPTION
## Summary

Target issue is #439 
Introduce support for referencing stored configurations using an identifier and version, allowing for more flexible configuration management. This change addresses the need for users to either provide a stored configuration or an ad-hoc configuration blob, ensuring that only one method is used at a time.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Requests can use either a stored reusable LLM config (id + version) or an ad-hoc inline config blob.
  * New request options to include provider raw responses and attach request metadata.

* **Improvements**
  * Validation enforces a single config path and clearer errors for resolution failures.
  * Runtime now resolves/normalizes config blobs and centralizes error handling.

* **Models**
  * Introduced typed config blob and re-exported config-related models for use across the app.

* **Tests**
  * Updated tests to the nested blob shape and added coverage for stored-config resolution and failure paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->