### PR TITLE
Onboarding : take multiple credentials from endpoint

### DIFF
--- a/backend/app/api/docs/collections/create.md
+++ b/backend/app/api/docs/collections/create.md
@@ -6,7 +6,7 @@ pipeline:
   documents stored in the cloud (see the `documents` interface).
 * Create an OpenAI [Vector
   Store](https://platform.openai.com/docs/api-reference/vector-stores)
-  based on those File's.
+  based on those file(s).
 * [To be deprecated] Attach the Vector Store to an OpenAI
   [Assistant](https://platform.openai.com/docs/api-reference/assistants). Use
   parameters in the request body relevant to an Assistant to flesh out
@@ -16,15 +16,15 @@ pipeline:
 
 If any one of the OpenAI interactions fail, all OpenAI resources are
 cleaned up. If a Vector Store is unable to be created, for example,
-all File's that were uploaded to OpenAI are removed from
+all file(s) that were uploaded to OpenAI are removed from
 OpenAI. Failure can occur from OpenAI being down, or some parameter
-value being invalid. It can also fail due to document types not be
+value being invalid. It can also fail due to document types not being
 accepted. This is especially true for PDFs that may not be parseable.
 
 Vector store/assistant will be created asynchronously. The immediate response
 from this endpoint is `collection_job` object which is going to contain
-the collection "job ID" and status.Once the collection has been created,
+the collection "job ID" and status. Once the collection has been created,
 information about the collection will be returned to the user via the
 callback URL. If a callback URL is not provided, clients can check the
-`collection job info` endpoint with the `job_id`, to retrieve the
+`collection job info` endpoint with the `job_id`, to retrieve
 information about the creation of collection.

--- a/backend/app/api/docs/collections/delete.md
+++ b/backend/app/api/docs/collections/delete.md
@@ -1,14 +1,14 @@
 Remove a collection from the platform. This is a two step process:
 
-1. Delete all OpenAI resources that were allocated: File's, the Vector
+1. Delete all OpenAI resources that were allocated: file(s), the Vector
    Store, and the Assistant.
-2. Delete the collection entry from the AI platform database.
+2. Delete the collection entry from the kaapi database.
 
 No action is taken on the documents themselves: the contents of the
 documents that were a part of the collection remain unchanged, those
 documents can still be accessed via the documents endpoints. The response from this
 endpoint will be a `collection_job` object which will contain the collection `job_id` and
-status. when you take the id returned and use the collection job
+status. When you take the id returned and use the collection job
 info endpoint, if the job is successful, you will get the status as successful.
 Additionally, if a `callback_url` was provided in the request body,
 you will receive a message indicating whether the deletion was successful or if it failed.

--- a/backend/app/api/docs/collections/delete.md
+++ b/backend/app/api/docs/collections/delete.md
@@ -8,7 +8,7 @@ No action is taken on the documents themselves: the contents of the
 documents that were a part of the collection remain unchanged, those
 documents can still be accessed via the documents endpoints. The response from this
 endpoint will be a `collection_job` object which will contain the collection `job_id` and
-status. When you take the id returned and use the collection job
-info endpoint, if the job is successful, you will get the status as successful.
+status. When you take the id returned and use the `collection job info` endpoint,
+if the job is successful, you will get the status as successful.
 Additionally, if a `callback_url` was provided in the request body,
 you will receive a message indicating whether the deletion was successful or if it failed.

--- a/backend/app/api/docs/collections/info.md
+++ b/backend/app/api/docs/collections/info.md
@@ -1,4 +1,4 @@
-Retrieve detailed information about `a specific collection by its ID` from the collection table. This endpoint returns the collection object including its project, organization,
-timestamps, and associated LLM service details (`llm_service_id`).
+Retrieve detailed information about a specific collection by its collection id. This endpoint returns the collection object including its project, organization,
+timestamps, and associated LLM service details (`llm_service_id` and `llm_service_name`).
 
-Additionally, if the `include_docs` flag in the request body is true then you will get a list of document IDs associated with a given collection as well. Documents returned are not only stored by the AI platform, but also by OpenAI.
+Additionally, if the `include_docs` flag in the request body is true then you will get a list of document IDs associated with a given collection as well. Note that, documents returned are not only stored by the AI platform, but also by OpenAI.

--- a/backend/app/api/docs/collections/job_info.md
+++ b/backend/app/api/docs/collections/job_info.md
@@ -3,7 +3,7 @@ Retrieve information about a collection job by the collection job ID. This endpo
 * Fetching the collection job object, including the collection job ID, the current status, and the associated collection details.
 
 * If the job has finished, has been successful and it was a job of creation of collection then this endpoint will fetch the associated collection details from the collection table, including:
-  - `llm_service_id`: The OpenAI assistant or model used for the collection.
+  - `llm_service_id` and `llm_service_name`.
   - Collection metadata such as ID, project, organization, and timestamps.
 
-* If the delete-collection job succeeds, the status is set to “successful” and the `collection_key` contains the ID of the collection that has been deleted.
+* If the delete-collection job succeeds, the status is set to “successful” and the `collection` key contains the ID of the collection that has been deleted.

--- a/backend/app/api/docs/collections/list.md
+++ b/backend/app/api/docs/collections/list.md
@@ -3,4 +3,4 @@ not deleted
 
 If a vector store was created - `llm_service_name` and `llm_service_id` in the response denote the name of the vector store (eg. 'openai vector store') and its id.
 
-[To be deprecated] If an assistant was created, `llm_service_name` and `llm_service_id` in the response denote the name of the model used in the assistant (eg. 'gpt-4o') and assistant id.
+[To be deprecated] If an assistant was created, `llm_service_name` and `llm_service_id` in the response denotes the name of the model used in the assistant (eg. 'gpt-4o') and assistant id.

--- a/backend/app/api/docs/config/create.md
+++ b/backend/app/api/docs/config/create.md
@@ -1,0 +1,46 @@
+Create a new LLM configuration with an initial version.
+
+Configurations allow you to store and manage reusable LLM parameters
+(such as temperature, max_tokens, model selection, etc.) with version control.
+
+**Key Features:**
+* Automatically creates an initial version (v1) with the provided configuration
+* Enforces unique configuration names per project
+* Stores provider-specific parameters as flexible JSON (config_blob)
+* Supports optional commit messages for tracking changes
+* Provider-agnostic storage - params are passed through to the provider as-is
+
+**Request Field Details:**
+
+- `name` (required): Unique configuration name
+- `description` (optional): Human-readable description for the config
+- `config_blob` (required): LLM configuration object containing:
+  - `completion` (required): Completion configuration with:
+    - `provider` (required): LLM provider (currently only "openai" supported)
+    - `params` (required): **Provider-specific parameters as flexible JSON**
+      - For OpenAI Responses API: `model`, `instructions`, `tools`, `temperature`, `metadata`, etc.
+      - Structure must match the provider's API specification exactly
+      - Stored as-is and passed through to the provider without modification
+- `commit_message` (optional): Message describing this initial version
+
+**Example for the config blob: OpenAI Responses API with File Search**
+
+```json
+"config_blob": {
+    "completion": {
+      "provider": "openai",
+      "params": {
+        "model": "gpt-4o-mini",
+        "instructions": "You are a helpful assistant for farming communities...",
+        "temperature": 1,
+        "tools": [
+          {
+            "type": "file_search",
+            "vector_store_ids": ["vs_692d71f3f5708191b1c46525f3c1e196"],
+            "max_num_results": 20
+          }]}}}
+```
+
+The configuration name must be unique within your project. Once created,
+you can create additional versions to track parameter changes while
+maintaining the configuration history.

--- a/backend/app/api/docs/config/create.md
+++ b/backend/app/api/docs/config/create.md
@@ -10,18 +10,6 @@ Configurations allow you to store and manage reusable LLM parameters
 * Supports optional commit messages for tracking changes
 * Provider-agnostic storage - params are passed through to the provider as-is
 
-**Request Field Details:**
-
-- `name` (required): Unique configuration name
-- `description` (optional): Human-readable description for the config
-- `config_blob` (required): LLM configuration object containing:
-  - `completion` (required): Completion configuration with:
-    - `provider` (required): LLM provider (currently only "openai" supported)
-    - `params` (required): **Provider-specific parameters as flexible JSON**
-      - For OpenAI Responses API: `model`, `instructions`, `tools`, `temperature`, `metadata`, etc.
-      - Structure must match the provider's API specification exactly
-      - Stored as-is and passed through to the provider without modification
-- `commit_message` (optional): Message describing this initial version
 
 **Example for the config blob: OpenAI Responses API with File Search**
 

--- a/backend/app/api/docs/config/create_version.md
+++ b/backend/app/api/docs/config/create_version.md
@@ -1,0 +1,7 @@
+Create a new version for an existing configuration.
+
+To create a new version, provide the `config_id` in the URL path and the new
+configuration parameters in the request body. The system will automatically
+create a new version under the same configuration with an incremented version number.
+Version numbers are automatically incremented sequentially (1, 2, 3, etc.)
+and cannot be manually set or skipped.

--- a/backend/app/api/docs/config/delete.md
+++ b/backend/app/api/docs/config/delete.md
@@ -1,5 +1,5 @@
 Delete a configuration and all its versions.
 
-This operation performs a soft delete, marking the configuration and all
+This operation performs a delete, marking the configuration and all
 associated versions as deleted in the database while retaining records
 for audit purposes.

--- a/backend/app/api/docs/config/delete.md
+++ b/backend/app/api/docs/config/delete.md
@@ -1,0 +1,5 @@
+Delete a configuration and all its versions.
+
+This operation performs a soft delete, marking the configuration and all
+associated versions as deleted in the database while retaining records
+for audit purposes.

--- a/backend/app/api/docs/config/delete_version.md
+++ b/backend/app/api/docs/config/delete_version.md
@@ -1,4 +1,4 @@
 Delete a specific version of a configuration.
 
-Performs a soft delete on the version, marking it as deleted while
+Performs a delete on the version, marking it as deleted while
 retaining the record for audit purposes.

--- a/backend/app/api/docs/config/delete_version.md
+++ b/backend/app/api/docs/config/delete_version.md
@@ -1,0 +1,4 @@
+Delete a specific version of a configuration.
+
+Performs a soft delete on the version, marking it as deleted while
+retaining the record for audit purposes.

--- a/backend/app/api/docs/config/get.md
+++ b/backend/app/api/docs/config/get.md
@@ -1,0 +1,5 @@
+Retrieve a specific configuration by its ID.
+
+Returns the configuration metadata including name, description, and
+timestamps. This endpoint provides configuration-level details but does
+not include version information.

--- a/backend/app/api/docs/config/get_version.md
+++ b/backend/app/api/docs/config/get_version.md
@@ -1,0 +1,4 @@
+Retrieve a specific version of a configuration.
+
+Returns the complete version details including the full configuration
+blob (config_blob) with all LLM parameters.

--- a/backend/app/api/docs/config/list.md
+++ b/backend/app/api/docs/config/list.md
@@ -1,0 +1,5 @@
+Retrieve all configurations for the current project.
+
+Returns a paginated list of configurations ordered by most recently
+updated first. Each configuration includes metadata (name, description,
+timestamps) but excludes version details for performance.

--- a/backend/app/api/docs/config/list_versions.md
+++ b/backend/app/api/docs/config/list_versions.md
@@ -1,0 +1,4 @@
+List all versions for a specific configuration.
+
+Returns versions in descending order (newest first), allowing you to
+see the evolution of configuration parameters over time.

--- a/backend/app/api/docs/config/update.md
+++ b/backend/app/api/docs/config/update.md
@@ -1,0 +1,5 @@
+Update a configuration's metadata (name or description).
+
+This endpoint modifies only the configuration-level metadata, not the
+LLM parameters themselves. To change LLM parameters, create a new
+version instead.

--- a/backend/app/api/docs/documents/permanent_delete.md
+++ b/backend/app/api/docs/documents/permanent_delete.md
@@ -1,4 +1,6 @@
-This operation soft deletes the document — meaning its metadata and reference are retained in the database, but it is marked as deleted. The actual file stored in cloud storage (e.g., S3) is permanently deleted, and this action is irreversible.
+This operation marks the document as deleted in the database while retaining its metadata. However, the actual file is
+permanently deleted from cloud storage (e.g., S3) and cannot be recovered. Only the database record remains for reference
+purposes.
 If the document is part of an active collection, those collections
 will be deleted using the collections delete interface. Noteably, this
 means all OpenAI Vector Store's and Assistant's to which this document

--- a/backend/app/api/docs/llm/llm_call.md
+++ b/backend/app/api/docs/llm/llm_call.md
@@ -12,7 +12,7 @@ for processing, and results are delivered via the callback URL when complete.
   - `auto_create` (optional, boolean, default false): Create new conversation if no ID provided
   - **Note**: Cannot specify both `id` and `auto_create=true`
 
-**`config`** (required) - Configuration for the LLM call (choose one mode):
+**`config`** (required) - Configuration for the LLM call (just choose one mode):
 
 - **Mode 1: Stored Configuration**
   - `id` (UUID): Configuration ID

--- a/backend/app/api/docs/llm/llm_call.md
+++ b/backend/app/api/docs/llm/llm_call.md
@@ -1,0 +1,42 @@
+Make an LLM API call using either a stored configuration or an ad-hoc configuration.
+
+This endpoint initiates an asynchronous LLM call job. The request is queued
+for processing, and results are delivered via the callback URL when complete.
+
+### Request Fields
+
+**`query`** (required) - Query parameters for this LLM call:
+- `input` (required, string, min 1 char): User question/prompt/query
+- `conversation` (optional, object): Conversation configuration
+  - `id` (optional, string): Existing conversation ID to continue
+  - `auto_create` (optional, boolean, default false): Create new conversation if no ID provided
+  - **Note**: Cannot specify both `id` and `auto_create=true`
+
+**`config`** (required) - Configuration for the LLM call (choose one mode):
+
+- **Mode 1: Stored Configuration**
+  - `id` (UUID): Configuration ID
+  - `version` (integer >= 1): Version number
+  - **Both required together**
+  - **Note**: When using stored configuration, do not include the `blob` field in the request body
+
+- **Mode 2: Ad-hoc Configuration**
+  - `blob` (object): Complete configuration object (see Create Config endpoint documentation for examples)
+    - `completion` (required):
+      - `provider` (required, string): Currently only "openai"
+      - `params` (required, object): Provider-specific parameters (flexible JSON)
+  - **Note**: When using ad-hoc configuration, do not include `id` and `version` fields
+
+**`callback_url`** (optional, HTTPS URL):
+- Webhook endpoint to receive the response
+- Must be a valid HTTPS URL
+- If not provided, response is only accessible through job status
+
+**`include_provider_raw_response`** (optional, boolean, default false):
+- When true, includes the unmodified raw response from the LLM provider
+
+**`request_metadata`** (optional, object):
+- Custom JSON metadata
+- Passed through unchanged in the response
+
+---

--- a/backend/app/api/docs/onboarding/onboarding.md
+++ b/backend/app/api/docs/onboarding/onboarding.md
@@ -22,7 +22,7 @@
 - If provided, the given credentials will be **encrypted** and stored as project credentials.
 - The `credential` parameter accepts a list of one or more credentials (e.g., an OpenAI key, Langfuse credentials, etc.).
 - If omitted, the project will be created **without credentials**.
-- We’ve also included a list of the providers currently supported.
+- We’ve also included a list of the providers currently supported by kaapi.
    ### Example: For sending multiple credentials -
    ```
    "credentials": [

--- a/backend/app/api/docs/onboarding/onboarding.md
+++ b/backend/app/api/docs/onboarding/onboarding.md
@@ -22,6 +22,7 @@
 - If provided, the given credentials will be **encrypted** and stored as project credentials.
 - The `credential` parameter accepts a list of one or more credentials (e.g., an OpenAI key, Langfuse credentials, etc.).
 - If omitted, the project will be created **without credentials**.
+- We’ve also included a list of the providers currently supported.
    ### Example: For sending multiple credentials -
    ```
    "credentials": [
@@ -39,7 +40,7 @@
      }
    ]
    ```
-   ### Supported Providers
+  ### Supported Providers
     - openai
     - langfuse
 ---

--- a/backend/app/api/docs/onboarding/onboarding.md
+++ b/backend/app/api/docs/onboarding/onboarding.md
@@ -18,9 +18,10 @@
 
 ---
 
-## 🔑 OpenAI API Key (Optional)
-- If provided, the API key will be **encrypted** and stored as project credentials.
-- If omitted, the project will be created **without OpenAI credentials**.
+## 🔑 Credentials (Optional)
+- If provided, the given credentials will be **encrypted** and stored as project credentials.
+- The `credential` parameter accepts a list of one or more credentials (e.g., an OpenAI key, Langfuse credentials, etc.).
+- If omitted, the project will be created **without credentials**.
 
 ---
 

--- a/backend/app/api/docs/onboarding/onboarding.md
+++ b/backend/app/api/docs/onboarding/onboarding.md
@@ -22,7 +22,26 @@
 - If provided, the given credentials will be **encrypted** and stored as project credentials.
 - The `credential` parameter accepts a list of one or more credentials (e.g., an OpenAI key, Langfuse credentials, etc.).
 - If omitted, the project will be created **without credentials**.
-
+   ### Example: For sending multiple credentials -
+   ```
+   "credentials": [
+     {
+       "openai": {
+         "api_key": "sk-proj-..."
+       }
+     },
+     {
+       "langfuse": {
+         "public_key": "pk-lf-...",
+         "secret_key": "sk-lf-...",
+         "host": "https://cloud.langfuse.com"
+       }
+     }
+   ]
+   ```
+   ### Supported Providers
+    - openai
+    - langfuse
 ---
 
 ## 🔄 Transactional Guarantee

--- a/backend/app/api/routes/config/config.py
+++ b/backend/app/api/routes/config/config.py
@@ -12,7 +12,7 @@ from app.models import (
     ConfigVersion,
     Message,
 )
-from app.utils import APIResponse
+from app.utils import APIResponse, load_description
 from app.api.permissions import Permission, require_permission
 
 router = APIRouter()
@@ -20,6 +20,7 @@ router = APIRouter()
 
 @router.post(
     "/",
+    description=load_description("config/create.md"),
     response_model=APIResponse[ConfigWithVersion],
     status_code=201,
     dependencies=[Depends(require_permission(Permission.REQUIRE_PROJECT))],
@@ -44,6 +45,7 @@ def create_config(
 
 @router.get(
     "/",
+    description=load_description("config/list.md"),
     response_model=APIResponse[list[ConfigPublic]],
     status_code=200,
     dependencies=[Depends(require_permission(Permission.REQUIRE_PROJECT))],
@@ -67,6 +69,7 @@ def list_configs(
 
 @router.get(
     "/{config_id}",
+    description=load_description("config/get.md"),
     response_model=APIResponse[ConfigPublic],
     status_code=200,
     dependencies=[Depends(require_permission(Permission.REQUIRE_PROJECT))],
@@ -88,6 +91,7 @@ def get_config(
 
 @router.patch(
     "/{config_id}",
+    description=load_description("config/update.md"),
     response_model=APIResponse[ConfigPublic],
     status_code=200,
     dependencies=[Depends(require_permission(Permission.REQUIRE_PROJECT))],
@@ -113,6 +117,7 @@ def update_config(
 
 @router.delete(
     "/{config_id}",
+    description=load_description("config/delete.md"),
     response_model=APIResponse[Message],
     status_code=200,
     dependencies=[Depends(require_permission(Permission.REQUIRE_PROJECT))],

--- a/backend/app/api/routes/config/version.py
+++ b/backend/app/api/routes/config/version.py
@@ -9,7 +9,7 @@ from app.models import (
     Message,
     ConfigVersionItems,
 )
-from app.utils import APIResponse
+from app.utils import APIResponse, load_description
 from app.api.permissions import Permission, require_permission
 
 router = APIRouter()
@@ -17,6 +17,7 @@ router = APIRouter()
 
 @router.post(
     "/{config_id}/versions",
+    description=load_description("config/create_version.md"),
     response_model=APIResponse[ConfigVersionPublic],
     status_code=201,
     dependencies=[Depends(require_permission(Permission.REQUIRE_PROJECT))],
@@ -43,6 +44,7 @@ def create_version(
 
 @router.get(
     "/{config_id}/versions",
+    description=load_description("config/list_versions.md"),
     response_model=APIResponse[list[ConfigVersionItems]],
     status_code=200,
     dependencies=[Depends(require_permission(Permission.REQUIRE_PROJECT))],
@@ -72,6 +74,7 @@ def list_versions(
 
 @router.get(
     "/{config_id}/versions/{version_number}",
+    description=load_description("config/get_version.md"),
     response_model=APIResponse[ConfigVersionPublic],
     status_code=200,
     dependencies=[Depends(require_permission(Permission.REQUIRE_PROJECT))],
@@ -98,6 +101,7 @@ def get_version(
 
 @router.delete(
     "/{config_id}/versions/{version_number}",
+    description=load_description("config/delete_version.md"),
     response_model=APIResponse[Message],
     status_code=200,
     dependencies=[Depends(require_permission(Permission.REQUIRE_PROJECT))],

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -109,7 +109,7 @@ async def upload_doc(
         None, description="Name of the transformer to apply when converting."
     ),
     callback_url: str
-    | None = Form(None, description="URL to call to report endpoint status"),
+    | None = Form(None, description="URL to call to report doc transformation status"),
 ):
     source_format, actual_transformer = pre_transform_validation(
         src_filename=src.filename,

--- a/backend/app/api/routes/llm.py
+++ b/backend/app/api/routes/llm.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter
 from app.api.deps import AuthContextDep, SessionDep
 from app.models import LLMCallRequest, LLMCallResponse, Message
 from app.services.llm.jobs import start_job
-from app.utils import APIResponse
+from app.utils import APIResponse, load_description
 
 
 logger = logging.getLogger(__name__)
@@ -32,6 +32,7 @@ def llm_callback_notification(body: APIResponse[LLMCallResponse]):
 
 @router.post(
     "/llm/call",
+    description=load_description("llm/llm_call.md"),
     response_model=APIResponse[Message],
     callbacks=llm_callback_router.routes,
 )

--- a/backend/app/api/routes/onboarding.py
+++ b/backend/app/api/routes/onboarding.py
@@ -25,7 +25,7 @@ def onboard_project_route(
     response = onboard_project(session=session, onboard_in=onboard_in)
 
     metadata = None
-    if onboard_in.credential:
+    if onboard_in.credentials:
         metadata = {"note": ("Given credential(s) have been saved for this project.")}
 
     return APIResponse.success_response(data=response, metadata=metadata)

--- a/backend/app/api/routes/onboarding.py
+++ b/backend/app/api/routes/onboarding.py
@@ -23,4 +23,9 @@ def onboard_project_route(
     current_user: User = Depends(get_current_active_superuser),
 ):
     response = onboard_project(session=session, onboard_in=onboard_in)
-    return APIResponse.success_response(data=response)
+
+    metadata = None
+    if onboard_in.credential:
+        metadata = {"note": ("Given credential(s) have been saved for this project.")}
+
+    return APIResponse.success_response(data=response, metadata=metadata)

--- a/backend/app/crud/onboarding.py
+++ b/backend/app/crud/onboarding.py
@@ -121,10 +121,14 @@ def onboard_project(
             session.add(cred_row)
 
             created_credentials.append(cred_row)
+
     session.commit()
+    cred_ids = [c.id for c in created_credentials]
+
     logger.info(
         "[onboard_project] Onboarding completed successfully. "
-        f"org_id={organization.id}, project_id={project.id}, user_id={user.id}"
+        f"org_id={organization.id}, project_id={project.id}, user_id={user.id}, "
+        f"cred_ids={cred_ids}"
     )
 
     return OnboardingResponse(

--- a/backend/app/crud/onboarding.py
+++ b/backend/app/crud/onboarding.py
@@ -104,9 +104,10 @@ def onboard_project(
 
     created_credentials: list[Credential] = []
 
-    if onboard_in.credential:
-        for item in onboard_in.credential:
-            provider_str, values = next(iter(item.items()))
+    if onboard_in.credentials:
+        for item in onboard_in.credentials:
+            (provider_str,) = item.keys()
+            values = item[provider_str]
 
             encrypted_credentials = encrypt_credentials(values)
 

--- a/backend/app/crud/onboarding.py
+++ b/backend/app/crud/onboarding.py
@@ -9,7 +9,6 @@ from app.crud import (
     get_project_by_name,
     get_user_by_email,
 )
-from app.core.providers import validate_provider, validate_provider_credentials
 from app.models import (
     APIKey,
     Credential,

--- a/backend/app/tests/api/routes/test_onboarding.py
+++ b/backend/app/tests/api/routes/test_onboarding.py
@@ -26,7 +26,7 @@ def test_onboard_project_new_organization_project_user(
         "email": email,
         "password": password,
         "user_name": user_name,
-        "credential": [
+        "credentials": [
             {"openai": {"api_key": openai_key}},
             {
                 "langfuse": {
@@ -186,7 +186,7 @@ def test_onboard_project_invalid_provider(
         "email": email,
         "password": password,
         "user_name": "User",
-        "credential": [{"totally_not_a_provider": {"foo": "bar"}}],
+        "credentials": [{"totally_not_a_provider": {"foo": "bar"}}],
     }
 
     response = client.post(
@@ -216,7 +216,7 @@ def test_onboard_project_non_dict_values_in_credential(
         "email": email,
         "password": password,
         "user_name": "User",
-        "credential": [{"openai": "sk-should-be-inside-object"}],
+        "credentials": [{"openai": "sk-should-be-inside-object"}],
     }
 
     response = client.post(
@@ -247,7 +247,7 @@ def test_onboard_project_missing_required_fields_for_openai(
         "email": email,
         "password": password,
         "user_name": "User",
-        "credential": [{"openai": {}}],  # missing api_key
+        "credentials": [{"openai": {}}],  # missing api_key
     }
 
     response = client.post(
@@ -278,7 +278,7 @@ def test_onboard_project_missing_required_fields_for_langfuse(
         "email": email,
         "password": password,
         "user_name": "User",
-        "credential": [
+        "credentials": [
             {"langfuse": {"secret_key": "sk-only"}}
         ],  # missing public_key/host
     }
@@ -311,7 +311,7 @@ def test_onboard_project_aggregates_multiple_credential_errors(
         "email": email,
         "password": password,
         "user_name": "User",
-        "credential": [
+        "credentials": [
             {"notreal": {"x": "y"}},
             {"openai": "should-be-dict"},
         ],

--- a/backend/app/tests/api/routes/test_onboarding.py
+++ b/backend/app/tests/api/routes/test_onboarding.py
@@ -17,6 +17,9 @@ def test_onboard_project_new_organization_project_user(
     password = random_lower_string()
     user_name = "Test User Onboard"
     openai_key = f"sk-{random_lower_string()}"
+    langfuse_secret_key = f"sk-lf-{random_lower_string()}"
+    langfuse_public_key = f"pk-lf-{random_lower_string()}"
+    langfuse_host = "https://cloud.langfuse.com"
 
     onboard_data = {
         "organization_name": org_name,
@@ -24,7 +27,16 @@ def test_onboard_project_new_organization_project_user(
         "email": email,
         "password": password,
         "user_name": user_name,
-        "openai_api_key": openai_key,
+        "credential": [
+            {"openai": {"api_key": openai_key}},
+            {
+                "langfuse": {
+                    "secret_key": langfuse_secret_key,
+                    "public_key": langfuse_public_key,
+                    "host": langfuse_host,
+                }
+            },
+        ],
     }
 
     response = client.post(

--- a/backend/app/tests/api/routes/test_onboarding.py
+++ b/backend/app/tests/api/routes/test_onboarding.py
@@ -1,10 +1,7 @@
-import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
-from pydantic import ValidationError
 
 from app.core.config import settings
-from app.models import OnboardingRequest
 from app.tests.utils.utils import random_email, random_lower_string
 from app.tests.utils.test_data import create_test_organization
 
@@ -174,50 +171,10 @@ def test_onboard_project_with_auto_generated_defaults(
     assert len(data["api_key"]) > 0
 
 
-def test_onboard_project_duplicate_project_in_organization(
-    client: TestClient, superuser_token_headers: dict[str, str], db: Session
-) -> None:
-    """Test onboarding fails when project already exists in the organization."""
-    org_name = "TestOrgOnboard"
-    project_name = "TestProjectOnboard"
-    email = random_email()
-    password = random_lower_string()
-
-    onboard_data = {
-        "organization_name": org_name,
-        "project_name": project_name,
-        "email": email,
-        "password": password,
-    }
-
-    # First request should succeed
-    response = client.post(
-        f"{settings.API_V1_STR}/onboard",
-        json=onboard_data,
-        headers=superuser_token_headers,
-    )
-    assert response.status_code == 201
-
-    # Second request with same org and project should fail
-    email2 = random_email()
-    onboard_data["email"] = email2
-
-    response = client.post(
-        f"{settings.API_V1_STR}/onboard",
-        json=onboard_data,
-        headers=superuser_token_headers,
-    )
-
-    assert response.status_code == 409
-    error_response = response.json()
-    assert "error" in error_response
-    assert "Project already exists" in error_response["error"]
-
-
 def test_onboard_project_invalid_provider(
     client: TestClient, superuser_token_headers: dict[str, str], db: Session
 ) -> None:
-    """Test onboarding fails when project already exists in the organization."""
+    """Test onboarding fails when an unsupported provider is specified."""
     org_name = "TestOrgOnboard"
     project_name = "TestProjectOnboard"
     email = random_email()

--- a/backend/app/tests/api/routes/test_onboarding.py
+++ b/backend/app/tests/api/routes/test_onboarding.py
@@ -1,8 +1,10 @@
+import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
+from pydantic import ValidationError
 
-from app.utils import mask_string
 from app.core.config import settings
+from app.models import OnboardingRequest
 from app.tests.utils.utils import random_email, random_lower_string
 from app.tests.utils.test_data import create_test_organization
 
@@ -170,3 +172,203 @@ def test_onboard_project_with_auto_generated_defaults(
     assert "@kaapi.org" in data["user_email"]
     assert "api_key" in data
     assert len(data["api_key"]) > 0
+
+
+def test_onboard_project_duplicate_project_in_organization(
+    client: TestClient, superuser_token_headers: dict[str, str], db: Session
+) -> None:
+    """Test onboarding fails when project already exists in the organization."""
+    org_name = "TestOrgOnboard"
+    project_name = "TestProjectOnboard"
+    email = random_email()
+    password = random_lower_string()
+
+    onboard_data = {
+        "organization_name": org_name,
+        "project_name": project_name,
+        "email": email,
+        "password": password,
+    }
+
+    # First request should succeed
+    response = client.post(
+        f"{settings.API_V1_STR}/onboard",
+        json=onboard_data,
+        headers=superuser_token_headers,
+    )
+    assert response.status_code == 201
+
+    # Second request with same org and project should fail
+    email2 = random_email()
+    onboard_data["email"] = email2
+
+    response = client.post(
+        f"{settings.API_V1_STR}/onboard",
+        json=onboard_data,
+        headers=superuser_token_headers,
+    )
+
+    assert response.status_code == 409
+    error_response = response.json()
+    assert "error" in error_response
+    assert "Project already exists" in error_response["error"]
+
+
+def test_onboard_project_invalid_provider(
+    client: TestClient, superuser_token_headers: dict[str, str], db: Session
+) -> None:
+    """Test onboarding fails when project already exists in the organization."""
+    org_name = "TestOrgOnboard"
+    project_name = "TestProjectOnboard"
+    email = random_email()
+    password = random_lower_string()
+
+    onboard_data = {
+        "organization_name": org_name,
+        "project_name": project_name,
+        "email": email,
+        "password": password,
+        "user_name": "User",
+        "credential": [{"totally_not_a_provider": {"foo": "bar"}}],
+    }
+
+    response = client.post(
+        f"{settings.API_V1_STR}/onboard",
+        json=onboard_data,
+        headers=superuser_token_headers,
+    )
+
+    assert response.status_code == 422
+    error_response = response.json()
+    assert "error" in error_response
+    assert "credential validation failed" in error_response["error"]
+
+
+def test_onboard_project_non_dict_values_in_credential(
+    client: TestClient, superuser_token_headers: dict[str, str], db: Session
+) -> None:
+    """Test onboarding fails when credential value for a provider is not an object/dict."""
+    org_name = "TestOrgOnboard"
+    project_name = "TestProjectOnboard"
+    email = random_email()
+    password = random_lower_string()
+
+    onboard_data = {
+        "organization_name": org_name,
+        "project_name": project_name,
+        "email": email,
+        "password": password,
+        "user_name": "User",
+        "credential": [{"openai": "sk-should-be-inside-object"}],
+    }
+
+    response = client.post(
+        f"{settings.API_V1_STR}/onboard",
+        json=onboard_data,
+        headers=superuser_token_headers,
+    )
+
+    assert response.status_code == 422
+    error_response = response.json()
+    assert "error" in error_response
+    assert "credential validation failed" in error_response["error"]
+    assert "must be an object/dict" in error_response["error"]
+
+
+def test_onboard_project_missing_required_fields_for_openai(
+    client: TestClient, superuser_token_headers: dict[str, str], db: Session
+) -> None:
+    """Test onboarding fails when OpenAI credential is missing required fields."""
+    org_name = "TestOrgOnboard"
+    project_name = "TestProjectOnboard"
+    email = random_email()
+    password = random_lower_string()
+
+    onboard_data = {
+        "organization_name": org_name,
+        "project_name": project_name,
+        "email": email,
+        "password": password,
+        "user_name": "User",
+        "credential": [{"openai": {}}],  # missing api_key
+    }
+
+    response = client.post(
+        f"{settings.API_V1_STR}/onboard",
+        json=onboard_data,
+        headers=superuser_token_headers,
+    )
+
+    assert response.status_code == 422
+    error_response = response.json()
+    assert "error" in error_response
+    assert "credential validation failed" in error_response["error"]
+    assert "openai" in error_response["error"]
+
+
+def test_onboard_project_missing_required_fields_for_langfuse(
+    client: TestClient, superuser_token_headers: dict[str, str], db: Session
+) -> None:
+    """Test onboarding fails when Langfuse credential is missing required fields."""
+    org_name = "TestOrgOnboard"
+    project_name = "TestProjectOnboard"
+    email = random_email()
+    password = random_lower_string()
+
+    onboard_data = {
+        "organization_name": org_name,
+        "project_name": project_name,
+        "email": email,
+        "password": password,
+        "user_name": "User",
+        "credential": [
+            {"langfuse": {"secret_key": "sk-only"}}
+        ],  # missing public_key/host
+    }
+
+    response = client.post(
+        f"{settings.API_V1_STR}/onboard",
+        json=onboard_data,
+        headers=superuser_token_headers,
+    )
+
+    assert response.status_code == 422
+    error_response = response.json()
+    assert "error" in error_response
+    assert "credential validation failed" in error_response["error"]
+    assert "langfuse" in error_response["error"]
+
+
+def test_onboard_project_aggregates_multiple_credential_errors(
+    client: TestClient, superuser_token_headers: dict[str, str], db: Session
+) -> None:
+    """Test onboarding aggregates multiple credential validation errors with index markers."""
+    org_name = "TestOrgOnboard"
+    project_name = "TestProjectOnboard"
+    email = random_email()
+    password = random_lower_string()
+
+    onboard_data = {
+        "organization_name": org_name,
+        "project_name": project_name,
+        "email": email,
+        "password": password,
+        "user_name": "User",
+        "credential": [
+            {"notreal": {"x": "y"}},
+            {"openai": "should-be-dict"},
+        ],
+    }
+
+    response = client.post(
+        f"{settings.API_V1_STR}/onboard",
+        json=onboard_data,
+        headers=superuser_token_headers,
+    )
+
+    assert response.status_code == 422
+    error_response = response.json()
+    assert "error" in error_response
+    assert "credential validation failed" in error_response["error"]
+    assert "[0]" in error_response["error"]
+    assert "[1]" in error_response["error"]

--- a/backend/app/tests/crud/test_onboarding.py
+++ b/backend/app/tests/crud/test_onboarding.py
@@ -38,7 +38,7 @@ def test_onboard_project_new_organization_project_user(db: Session) -> None:
         email=email,
         password=password,
         user_name=user_name,
-        openai_api_key=openai_key,
+        credential=[{"openai": {"api_key": openai_key}}],
     )
 
     response = onboard_project(session=db, onboard_in=onboard_request)
@@ -246,7 +246,7 @@ def test_onboard_project_response_data_integrity(db: Session) -> None:
         email=email,
         password=password,
         user_name=user_name,
-        openai_api_key=openai_key,
+        credential=[{"openai": {"api_key": openai_key}}],
     )
 
     response = onboard_project(session=db, onboard_in=onboard_request)

--- a/backend/app/tests/crud/test_onboarding.py
+++ b/backend/app/tests/crud/test_onboarding.py
@@ -38,7 +38,7 @@ def test_onboard_project_new_organization_project_user(db: Session) -> None:
         email=email,
         password=password,
         user_name=user_name,
-        credential=[{"openai": {"api_key": openai_key}}],
+        credentials=[{"openai": {"api_key": openai_key}}],
     )
 
     response = onboard_project(session=db, onboard_in=onboard_request)


### PR DESCRIPTION
## Summary

Target issue is #422 

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

## Notes

- Taking a list of credentials now from this endpoint which can have one or more than one credentials out of the allowed providers(openai, langfuse,etc)
- this is an example of the input we will take now, in the credential paraemeter of the onboarding request body - 
```     
"credential": [
            {"openai": {"api_key": openai_key}},
            {
                "langfuse": {
                    "secret_key": langfuse_secret_key,
                    "public_key": langfuse_public_key,
                    "host": langfuse_host,
                }
            },
        ],
    }
```

- ``app/models/onboarding`` : Added validation for the credential field to make sure it’s a proper list of single-key provider objects (like {"openai":   {"api_key": "..."}}).
The validator now checks that each provider is supported, the value is a dictionary, and all required fields are present.
If there are multiple issues, it collects and returns all of them together with clear, indexed error messages.
Also added tests to cover valid cases and all major error scenarios.

- ``app/routes/onboarding`` : If the credential parameter has valid values and they have been saved to the credential table, you get an additional metadata in your response body which is - 

      ```metadata = {"note": ("Given credential(s) have been saved for this project.")}```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding accepts multiple credential providers (e.g., OpenAI, Langfuse); credentials stored encrypted and onboarding responses may include metadata confirming storage
* **Bug Fixes / Behavior**
  * All-or-nothing persistence for credential storage on failure; omitting credentials creates the project without saving any
* **Documentation**
  * Added onboarding examples and “Supported Providers”; new docs for config lifecycle and LLM call; clarified collections, jobs, delete/permanent-delete, and callback behaviors; endpoint docs surfaced in API descriptions
* **Tests**
  * Expanded tests for multi-credential validation, aggregated errors, and provider-specific cases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->