### PR TITLE
Evaluation: Fetch Scores

### DIFF
--- a/backend/app/api/docs/evaluation/get_evaluation.md
+++ b/backend/app/api/docs/evaluation/get_evaluation.md
@@ -8,7 +8,7 @@ Retrieves comprehensive information about an evaluation run including its curren
 
 ## Query Parameters
 
-- **get_trace_info** (optional, default: false): If true, fetch and include Langfuse trace scores with Q&A context. On first request, data is fetched from Langfuse and cached in the score column. Subsequent requests return cached data.
+- **get_trace_info** (optional, default: false): If true, fetch and include Langfuse trace scores with Q&A context. On first request, data is fetched from Langfuse and cached in the score column. Subsequent requests return cached data. Only available for completed evaluations.
 
 - **resync_score** (optional, default: false): If true, clear cached scores and re-fetch from Langfuse. Useful when new evaluators have been added or scores have been updated. Requires get_trace_info=true.
 
@@ -24,10 +24,61 @@ EvaluationRunPublic with current status and results:
 - status: Current status (pending, running, completed, failed)
 - total_items: Total number of items being evaluated
 - completed_items: Number of items completed so far
-- results: Evaluation results (when completed)
+- score: Evaluation scores (when get_trace_info=true and status=completed)
 - error_message: Error message if failed
 - created_at: Timestamp when the evaluation was created
 - updated_at: Timestamp when the evaluation was last updated
+
+## Score Format
+
+When `get_trace_info=true` and evaluation is completed, the `score` field contains:
+
+```json
+{
+  "summary_scores": [
+    {
+      "name": "cosine_similarity",
+      "avg": 0.87,
+      "std": 0.12,
+      "total_pairs": 50,
+      "data_type": "NUMERIC"
+    },
+    {
+      "name": "response_category",
+      "distribution": {"CORRECT": 10, "PARTIAL": 5, "INCORRECT": 2},
+      "total_pairs": 17,
+      "data_type": "CATEGORICAL"
+    }
+  ],
+  "traces": [
+    {
+      "trace_id": "uuid-123",
+      "question": "What is 2+2?",
+      "llm_answer": "4",
+      "ground_truth_answer": "4",
+      "scores": [
+        {
+          "name": "cosine_similarity",
+          "value": 0.95,
+          "data_type": "NUMERIC"
+        },
+        {
+          "name": "correctness",
+          "value": 1,
+          "data_type": "NUMERIC",
+          "comment": "Response is correct"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Notes:**
+- Only complete scores are included (scores where all traces have been rated)
+- Numeric values are rounded to 2 decimal places
+- NUMERIC scores show `avg` and `std` in summary
+- CATEGORICAL scores show `distribution` counts in summary
 
 ## Usage
 

--- a/backend/app/api/docs/evaluation/get_evaluation.md
+++ b/backend/app/api/docs/evaluation/get_evaluation.md
@@ -6,6 +6,12 @@ Retrieves comprehensive information about an evaluation run including its curren
 
 - **evaluation_id**: ID of the evaluation run
 
+## Query Parameters
+
+- **get_trace_info** (optional, default: false): If true, fetch and include Langfuse trace scores with Q&A context. On first request, data is fetched from Langfuse and cached in the score column. Subsequent requests return cached data.
+
+- **resync_score** (optional, default: false): If true, clear cached scores and re-fetch from Langfuse. Useful when new evaluators have been added or scores have been updated. Requires get_trace_info=true.
+
 ## Returns
 
 EvaluationRunPublic with current status and results:

--- a/backend/app/api/routes/evaluation.py
+++ b/backend/app/api/routes/evaluation.py
@@ -646,13 +646,7 @@ def get_evaluation_run_status(
     if get_trace_info:
         # Only fetch trace info for completed evaluations
         if eval_run.status != "completed":
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    "Trace info is only available for completed evaluations. "
-                    f"Current status: {eval_run.status}"
-                ),
-            )
+            return eval_run
 
         # Get Langfuse client
         langfuse = get_langfuse_client(

--- a/backend/app/api/routes/evaluation.py
+++ b/backend/app/api/routes/evaluation.py
@@ -663,7 +663,11 @@ def get_evaluation_run_status(
     if get_trace_info:
         # Only fetch trace info for completed evaluations
         if eval_run.status != "completed":
-            return APIResponse.success_response(data=eval_run)
+            return APIResponse.failure_response(
+                error=f"Trace info is only available for completed evaluations. "
+                f"Current status: {eval_run.status}",
+                data=eval_run,
+            )
 
         # Check if we already have cached scores (before any slow operations)
         has_cached_score = eval_run.score is not None and "traces" in eval_run.score

--- a/backend/app/crud/evaluations/core.py
+++ b/backend/app/crud/evaluations/core.py
@@ -321,7 +321,7 @@ def get_or_fetch_score(
     Get cached score with trace info or fetch from Langfuse and update.
 
     This function implements a cache-on-first-request pattern:
-    - If score already has 'scores.traces' key, return it
+    - If score already has 'traces' key, return it
     - Otherwise, fetch from Langfuse, update score column, and return
     - If force_refetch is True, always fetch fresh data from Langfuse
 
@@ -339,11 +339,7 @@ def get_or_fetch_score(
         Exception: If Langfuse API calls fail
     """
     # Check if score already exists with traces
-    has_score = (
-        eval_run.score is not None
-        and "scores" in eval_run.score
-        and "traces" in eval_run.score.get("scores", {})
-    )
+    has_score = eval_run.score is not None and "traces" in eval_run.score
     if not force_refetch and has_score:
         logger.info(
             f"[get_or_fetch_score] Returning existing score | evaluation_id={eval_run.id}"
@@ -366,8 +362,7 @@ def get_or_fetch_score(
     # Update score column using existing helper
     update_evaluation_run(session=session, eval_run=eval_run, score=score)
 
-    # Get trace count from new format
-    total_traces = len(score.get("scores", {}).get("traces", []))
+    total_traces = len(score.get("traces", []))
     logger.info(
         f"[get_or_fetch_score] Updated score | "
         f"evaluation_id={eval_run.id} | total_traces={total_traces}"

--- a/backend/app/crud/evaluations/core.py
+++ b/backend/app/crud/evaluations/core.py
@@ -321,7 +321,7 @@ def get_or_fetch_score(
     Get cached score with trace info or fetch from Langfuse and update.
 
     This function implements a cache-on-first-request pattern:
-    - If score already has 'traces' key (enriched format), return it
+    - If score already has 'traces' key, return it
     - Otherwise, fetch from Langfuse, update score column, and return
     - If force_refetch is True, always fetch fresh data from Langfuse
 
@@ -338,11 +338,9 @@ def get_or_fetch_score(
         ValueError: If the run is not found in Langfuse
         Exception: If Langfuse API calls fail
     """
-    # Check if score already has enriched format (has 'traces' key) and not forcing refetch
     if not force_refetch and eval_run.score is not None and "traces" in eval_run.score:
         logger.info(
-            f"[get_or_fetch_score] Returning cached score | "
-            f"evaluation_id={eval_run.id}"
+            f"[get_or_fetch_score] Returning cached score | evaluation_id={eval_run.id}"
         )
         return eval_run.score
 
@@ -359,12 +357,8 @@ def get_or_fetch_score(
         run_name=eval_run.run_name,
     )
 
-    # Update score column
-    eval_run.score = score
-    eval_run.updated_at = now()
-    session.add(eval_run)
-    session.commit()
-    session.refresh(eval_run)
+    # Update score column using existing helper
+    update_evaluation_run(session=session, eval_run=eval_run, score=score)
 
     logger.info(
         f"[get_or_fetch_score] Updated score | "

--- a/backend/app/crud/evaluations/langfuse.py
+++ b/backend/app/crud/evaluations/langfuse.py
@@ -48,7 +48,7 @@ def create_langfuse_dataset_run(
                          "question": "What is 2+2?",
                          "generated_output": "4",
                          "ground_truth": "4",
-                         "response_id": "resp_0b99aadfead1fb62006908e7f540c48197bd110183a347c1d8",
+                         "response_id": "resp_0b99aadf...",
                          "usage": {
                              "input_tokens": 69,
                              "output_tokens": 258,
@@ -195,7 +195,8 @@ def update_traces_with_cosine_scores(
 
         if not trace_id:
             logger.warning(
-                "[update_traces_with_cosine_scores] Score item missing trace_id, skipping"
+                "[update_traces_with_cosine_scores] "
+                "Score item missing trace_id, skipping"
             )
             continue
 
@@ -242,7 +243,8 @@ def upload_dataset_to_langfuse(
     """
     logger.info(
         f"[upload_dataset_to_langfuse] Uploading dataset to Langfuse | "
-        f"dataset={dataset_name} | items={len(items)} | duplication_factor={duplication_factor}"
+        f"dataset={dataset_name} | items={len(items)} | "
+        f"duplication_factor={duplication_factor}"
     )
 
     try:
@@ -269,7 +271,8 @@ def upload_dataset_to_langfuse(
                 except Exception as e:
                     logger.error(
                         f"[upload_dataset_to_langfuse] Failed to upload item | "
-                        f"duplicate={duplicate_num + 1} | question={item['question'][:50]}... | {e}"
+                        f"duplicate={duplicate_num + 1} | "
+                        f"question={item['question'][:50]}... | {e}"
                     )
 
             # Flush after each original item's duplicates to prevent race conditions
@@ -282,8 +285,9 @@ def upload_dataset_to_langfuse(
         langfuse_dataset_id = dataset.id if hasattr(dataset, "id") else None
 
         logger.info(
-            f"[upload_dataset_to_langfuse] Successfully uploaded items to Langfuse dataset | "
-            f"items={total_uploaded} | dataset={dataset_name} | id={langfuse_dataset_id}"
+            f"[upload_dataset_to_langfuse] Successfully uploaded to Langfuse | "
+            f"items={total_uploaded} | dataset={dataset_name} | "
+            f"id={langfuse_dataset_id}"
         )
 
         return langfuse_dataset_id, total_uploaded

--- a/backend/app/crud/evaluations/langfuse.py
+++ b/backend/app/crud/evaluations/langfuse.py
@@ -5,7 +5,7 @@ This module handles:
 1. Creating dataset runs in Langfuse
 2. Creating traces for each evaluation item
 3. Uploading results to Langfuse for visualization
-4. Fetching trace scores from Langfuse for enriched results
+4. Fetching trace scores from Langfuse for results
 """
 
 import logging
@@ -471,24 +471,24 @@ def fetch_trace_scores_from_langfuse(
                 continue
 
         # 4. Calculate aggregated stats
-        enriched_score: dict[str, Any] = {
+        score: dict[str, Any] = {
             "total_pairs": len(traces),
             "traces": traces,
         }
 
         for score_name, values in score_aggregations.items():
             if values:
-                enriched_score[score_name] = {
+                score[score_name] = {
                     "avg": float(np.mean(values)),
                     "std": float(np.std(values)),
                 }
 
         logger.info(
-            f"[fetch_trace_scores_from_langfuse] Successfully fetched enriched scores | "
+            f"[fetch_trace_scores_from_langfuse] Successfully fetched scores | "
             f"total_traces={len(traces)} | score_types={list(score_aggregations.keys())}"
         )
 
-        return enriched_score
+        return score
 
     except ValueError:
         # Re-raise ValueError for "run not found" case

--- a/backend/app/crud/evaluations/langfuse.py
+++ b/backend/app/crud/evaluations/langfuse.py
@@ -355,7 +355,7 @@ def fetch_trace_scores_from_langfuse(
         run_name: Name of the evaluation run
 
     Returns:
-        Enriched score data with per-trace scores and Q&A context:
+        Score data with per-trace scores and Q&A context:
         {
             "cosine_similarity": {"avg": 0.87, "std": 0.12},
             "total_pairs": 50,
@@ -413,8 +413,6 @@ def fetch_trace_scores_from_langfuse(
         for trace_id in trace_ids:
             try:
                 trace = langfuse.api.trace.get(trace_id)
-
-                # Extract Q&A data from trace
                 trace_data: dict[str, Any] = {
                     "trace_id": trace_id,
                     "question": "",
@@ -491,7 +489,6 @@ def fetch_trace_scores_from_langfuse(
         return score
 
     except ValueError:
-        # Re-raise ValueError for "run not found" case
         raise
     except Exception as e:
         logger.error(

--- a/backend/app/tests/api/routes/test_evaluation.py
+++ b/backend/app/tests/api/routes/test_evaluation.py
@@ -86,7 +86,9 @@ class TestDatasetUploadValidation:
             )
 
             assert response.status_code == 200, response.text
-            data = response.json()
+            response_data = response.json()
+            assert response_data["success"] is True
+            data = response_data["data"]
 
             assert data["dataset_name"] == "test_dataset"
             assert data["original_items"] == 3
@@ -165,7 +167,9 @@ class TestDatasetUploadValidation:
             )
 
             assert response.status_code == 200, response.text
-            data = response.json()
+            response_data = response.json()
+            assert response_data["success"] is True
+            data = response_data["data"]
 
             # Should only have 2 valid items (first and last rows)
             assert data["original_items"] == 2
@@ -178,7 +182,7 @@ class TestDatasetUploadDuplication:
     def test_upload_with_default_duplication(
         self, client, user_api_key_header, valid_csv_content
     ):
-        """Test uploading with default duplication factor (5)."""
+        """Test uploading with default duplication factor (1)."""
         with (
             patch("app.core.cloud.get_cloud_storage") as _mock_storage,
             patch(
@@ -193,7 +197,7 @@ class TestDatasetUploadDuplication:
         ):
             mock_store_upload.return_value = "s3://bucket/datasets/test_dataset.csv"
             mock_get_langfuse_client.return_value = Mock()
-            mock_langfuse_upload.return_value = ("test_dataset_id", 15)
+            mock_langfuse_upload.return_value = ("test_dataset_id", 3)
 
             filename, file_obj = create_csv_file(valid_csv_content)
 
@@ -202,17 +206,19 @@ class TestDatasetUploadDuplication:
                 files={"file": (filename, file_obj, "text/csv")},
                 data={
                     "dataset_name": "test_dataset",
-                    # duplication_factor not provided, should default to 5
+                    # duplication_factor not provided, should default to 1
                 },
                 headers=user_api_key_header,
             )
 
             assert response.status_code == 200, response.text
-            data = response.json()
+            response_data = response.json()
+            assert response_data["success"] is True
+            data = response_data["data"]
 
-            assert data["duplication_factor"] == 5
+            assert data["duplication_factor"] == 1
             assert data["original_items"] == 3
-            assert data["total_items"] == 15  # 3 items * 5 duplication
+            assert data["total_items"] == 3  # 3 items * 1 duplication
 
     def test_upload_with_custom_duplication(
         self, client, user_api_key_header, valid_csv_content
@@ -247,7 +253,9 @@ class TestDatasetUploadDuplication:
             )
 
             assert response.status_code == 200, response.text
-            data = response.json()
+            response_data = response.json()
+            assert response_data["success"] is True
+            data = response_data["data"]
 
             assert data["duplication_factor"] == 4
             assert data["original_items"] == 3
@@ -287,7 +295,9 @@ class TestDatasetUploadDuplication:
             )
 
             assert response.status_code == 200, response.text
-            data = response.json()
+            response_data = response.json()
+            assert response_data["success"] is True
+            data = response_data["data"]
 
             # Verify the description is stored
             dataset = db.exec(
@@ -376,7 +386,9 @@ class TestDatasetUploadDuplication:
             )
 
             assert response.status_code == 200, response.text
-            data = response.json()
+            response_data = response.json()
+            assert response_data["success"] is True
+            data = response_data["data"]
 
             assert data["duplication_factor"] == 1
             assert data["original_items"] == 3


### PR DESCRIPTION
## Summary

Target issue is #454

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

## Notes
  * Evaluation run status endpoint now retrieves and displays Langfuse trace scores with associated Q&A context (question, answer, ground truth).
  * Scores are automatically fetched from database after initial retrieval for improved performance.
  * Added option to force re-fetch and update database when new evaluators are added or existing scores have been updated.
  * Score column is updated in below format
  
  ```
  {
  "score": {
    "cosine": {
      "avg": 0.6333919361423369,
      "std": 0.08478813281478952
    },
    "llm-as-a-juddge": {
      "avg": 0.0,
      "std": 0.0
    },
    "total_pairs": 4,
    "traces": [
      {
        "trace_id": "e80421ee-043b-4fed-93e9-cb9b3b7c82ee",
        "cosine_similarity": {
          "score": 0.5326538788039078,
          "comment": "it is similar"
        },
        "llm_as_a_juddge_score": {
          "score": 0.5326538788039078,
          "comment": "it is similar"
        },
        "question": "what is your name",
        "llm_answer": "my name is kaapi",
        "ground_truth_answer": "Kaapi is my name"
      },
      {
        "cosine_similarity": {
          "score": 0.5326538788039078,
          "comment": "it is similar"
        },
        "llm_as_a_juddge_score": {
          "score": 0.5326538788039078,
          "comment": "it is similar"
        },
        "question": "what is your name",
        "llm_answer": "my name is kaapi",
        "ground_truth_answer": "Kaapi is my name"
      }
    ]
  }
}
  ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evaluation status endpoint can include per-trace Q&A scores and aggregated summary (cached); option to force resync to refresh scores. Responses now include a unified success/data envelope.
* **Bug Fixes**
  * Validation for incompatible query combinations; improved error handling and clearer messages when fetching or persisting trace scores fails.
* **Documentation**
  * API docs updated with new query parameters, score payload format, examples, and usage notes.
* **Tests**
  * Tests updated for wrapped API responses and adjusted dataset duplication defaults.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->