### PR TITLE
Add Langfuse observability to Unified API

### DIFF
--- a/backend/app/core/langfuse/langfuse.py
+++ b/backend/app/core/langfuse/langfuse.py
@@ -148,17 +148,10 @@ def observe_llm_execution(
                 logger.warning(f"[Langfuse] Failed to initialize client: {e}")
                 return func(completion_config, query, **kwargs)
 
-            trace_metadata = {
-                "provider": completion_config.provider,
-            }
-
-            if query.conversation and query.conversation.id:
-                trace_metadata["conversation_id"] = query.conversation.id
 
             trace = langfuse.trace(
                 name="unified-llm-call",
                 input=query.input,
-                metadata=trace_metadata,
                 tags=[completion_config.provider],
             )
 

--- a/backend/app/core/langfuse/langfuse.py
+++ b/backend/app/core/langfuse/langfuse.py
@@ -148,7 +148,6 @@ def observe_llm_execution(
                 logger.warning(f"[Langfuse] Failed to initialize client: {e}")
                 return func(completion_config, query, **kwargs)
 
-
             trace = langfuse.trace(
                 name="unified-llm-call",
                 input=query.input,

--- a/backend/app/core/langfuse/langfuse.py
+++ b/backend/app/core/langfuse/langfuse.py
@@ -1,10 +1,12 @@
 import uuid
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
+from functools import wraps
 
 from asgi_correlation_id import correlation_id
 from langfuse import Langfuse
 from langfuse.client import StatefulGenerationClient, StatefulTraceClient
+from app.models.llm import CompletionConfig, QueryParams, LLMCallResponse
 
 logger = logging.getLogger(__name__)
 
@@ -107,3 +109,110 @@ class LangfuseTracer:
 
     def flush(self):
         self.langfuse.flush()
+
+
+def observe_llm_execution(
+    session_id: str | None = None,
+    credentials: dict | None = None,
+):
+    """Decorator to add Langfuse observability to LLM provider execute methods.
+
+    Args:
+        credentials: Langfuse credentials with public_key, secret_key, and host
+        session_id: Session ID for grouping traces (conversation_id)
+
+    Usage:
+        decorated_execute = observe_llm_execution(
+            credentials=langfuse_creds,
+            session_id=conversation_id
+        )(provider_instance.execute)
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(completion_config: CompletionConfig, query: QueryParams, **kwargs):
+            # Skip observability if no credentials provided
+            if not credentials:
+                logger.info("[Langfuse] No credentials - skipping observability")
+                return func(completion_config, query, **kwargs)
+
+            try:
+                langfuse = Langfuse(
+                    public_key=credentials.get("public_key"),
+                    secret_key=credentials.get("secret_key"),
+                    host=credentials.get("host"),
+                )
+            except Exception as e:
+                logger.warning(f"[Langfuse] Failed to initialize client: {e}")
+                return func(completion_config, query, **kwargs)
+
+            trace_metadata = {
+                "provider": completion_config.provider,
+            }
+
+            if query.conversation and query.conversation.id:
+                trace_metadata["conversation_id"] = query.conversation.id
+
+            trace = langfuse.trace(
+                name="unified-llm-call",
+                input=query.input,
+                metadata=trace_metadata,
+                tags=[completion_config.provider],
+            )
+
+            generation = trace.generation(
+                name=f"{completion_config.provider}-completion",
+                input=query.input,
+                model=completion_config.params.get("model"),
+            )
+
+            try:
+                # Execute the actual LLM call
+                response: LLMCallResponse | None
+                error: str | None
+                response, error = func(completion_config, query, **kwargs)
+
+                if response:
+                    generation.end(
+                        output={
+                            "status": "success",
+                            "output": response.response.output.text,
+                        },
+                        usage_details={
+                            "input": response.usage.input_tokens,
+                            "output": response.usage.output_tokens,
+                        },
+                        model=response.response.model,
+                    )
+
+                    trace.update(
+                        output={
+                            "status": "success",
+                            "output": response.response.output.text,
+                        },
+                        session_id=session_id or response.response.conversation_id,
+                    )
+                else:
+                    error_msg = error or "Unknown error"
+                    generation.end(output={"error": error_msg})
+                    trace.update(
+                        output={"status": "failure", "error": error_msg},
+                        session_id=session_id,
+                    )
+
+                langfuse.flush()
+                return response, error
+
+            except Exception as e:
+                error_msg = str(e)
+                generation.end(output={"error": error_msg})
+                trace.update(
+                    output={"status": "failure", "error": error_msg},
+                    session_id=session_id,
+                )
+                langfuse.flush()
+                raise
+
+        return wrapper
+
+    return decorator

--- a/backend/app/core/langfuse/langfuse.py
+++ b/backend/app/core/langfuse/langfuse.py
@@ -132,7 +132,9 @@ def observe_llm_execution(
         @wraps(func)
         def wrapper(completion_config: CompletionConfig, query: QueryParams, **kwargs):
             # Skip observability if no credentials provided
-            if not credentials:
+            if not credentials or not all(
+                key in credentials for key in ["public_key", "secret_key", "host"]
+            ):
                 logger.info("[Langfuse] No credentials - skipping observability")
                 return func(completion_config, query, **kwargs)
 

--- a/backend/app/core/langfuse/langfuse.py
+++ b/backend/app/core/langfuse/langfuse.py
@@ -132,9 +132,7 @@ def observe_llm_execution(
         @wraps(func)
         def wrapper(completion_config: CompletionConfig, query: QueryParams, **kwargs):
             # Skip observability if no credentials provided
-            if not credentials or not all(
-                key in credentials for key in ["public_key", "secret_key", "host"]
-            ):
+            if not credentials:
                 logger.info("[Langfuse] No credentials - skipping observability")
                 return func(completion_config, query, **kwargs)
 


### PR DESCRIPTION
## Summary

Target issue is #438 
This PR introduces Langfuse observability into the LLM provider execution flow by wrapping provider_instance.execute with a configurable decorator. This allows every LLM call to automatically generate:
- A Langfuse trace
- A generation event
- Success/failure metadata
- Token usage reporting
- Optional session grouping via conversation_id

This enables unified tracing, debugging, and analytics across all LLM providers.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional LLM observability that traces interactions, captures model/session details, usage metrics, and outputs.
  * Session/conversation tracking to correlate related requests and attach context to traces.
  * Observability is automatically applied to LLM job execution when credentials are provided.

* **Bug Fixes**
  * Gracefully bypasses observability if credentials or client initialization fail and ensures telemetry is flushed on success or error.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->