### PR TITLE
Refactor CI/CD workflows to use AWS resource prefix for repository and service names

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: AWS_ENV_VARS
 
     permissions:
       packages: write
@@ -32,7 +33,7 @@ jobs:
       - name: Build and Push Docker Image
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: ${{ github.event.repository.name }}-repo
+          REPOSITORY: ${{ vars.AWS_RESOURCE_PREFIX }}-repo
           TAG: ${{ github.ref_name }}
         run: |
           docker build -t $REGISTRY/$REPOSITORY:latest ./backend
@@ -41,6 +42,6 @@ jobs:
       - name: Deploy to ECS
         run: |
           aws ecs update-service \
-            --cluster ${{ github.event.repository.name }}-cluster \
-            --service ${{ github.event.repository.name }}-service \
+            --cluster ${{ vars.AWS_RESOURCE_PREFIX }}-cluster \
+            --service ${{ vars.AWS_RESOURCE_PREFIX }}-service \
             --force-new-deployment

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: AWS_ENV_VARS
 
     permissions:
       packages: write
@@ -34,11 +35,11 @@ jobs:
       - name: Build and Push Docker Image
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: ${{ github.event.repository.name }}-staging-repo
+          REPOSITORY: ${{ vars.AWS_RESOURCE_PREFIX }}-staging-repo
         run: |
           docker build -t $REGISTRY/$REPOSITORY:latest ./backend
           docker push $REGISTRY/$REPOSITORY:latest
 
       - name: Deploy to ECS
         run: |
-          aws ecs update-service --cluster ${{ github.event.repository.name }}-staging-cluster --service ${{ github.event.repository.name }}-staging-service --force-new-deployment
+          aws ecs update-service --cluster ${{ vars.AWS_RESOURCE_PREFIX }}-staging-cluster --service ${{ vars.AWS_RESOURCE_PREFIX }}-staging-service --force-new-deployment


### PR DESCRIPTION
## Summary

Target issue is #465
Our repo name will change from `ai-platform` to `kaapi-backend`, but this change should not impact our continuous deployment. In order to avoid making changes to AWS resources (renaming them), we are storing the `ai-platform` prefix in the github env vars and using that env in the cd files.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.
