### PR TITLE
Collection: Adding input parameter "provider"

### DIFF
--- a/backend/app/models/collection.py
+++ b/backend/app/models/collection.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID, uuid4
 
 from pydantic import HttpUrl, model_validator
@@ -28,7 +28,7 @@ class Collection(SQLModel, table=True):
     )
     llm_service_name: str = Field(
         nullable=False,
-        sa_column_kwargs={"comment": "Name of the LLM service provider"},
+        sa_column_kwargs={"comment": "Name of the LLM service"},
     )
 
     # Foreign keys
@@ -145,8 +145,17 @@ class CallbackRequest(SQLModel):
     )
 
 
+class ProviderOptions(SQLModel):
+    """LLM provider configuration."""
+
+    provider: Literal["openai"] = Field(
+        default="openai", description="LLM provider to use for this collection"
+    )
+
+
 class CreationRequest(
     DocumentOptions,
+    ProviderOptions,
     AssistantOptions,
     CallbackRequest,
 ):


### PR DESCRIPTION
## Summary

Target issue is #490 

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.

## Notes

- Just adding an input parameter, "provider" as we will be extending the collection module to be able to make knowledge base with providers other than openai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Collection creation now supports explicit LLM provider configuration options. Users can specify their preferred LLM service provider when creating new collections, with OpenAI currently available as the primary provider option. This enhancement enables greater control over service dependencies and ensures proper provider configuration during the collection creation and initialization process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->