### PR TITLE
Collection: Fixing crawler fixture

### DIFF
--- a/backend/app/tests/api/routes/documents/conftest.py
+++ b/backend/app/tests/api/routes/documents/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+from starlette.testclient import TestClient
+
+from app.tests.utils.auth import TestAuthContext
+from app.tests.utils.document import WebCrawler
+
+
+@pytest.fixture
+def crawler(client: TestClient, user_api_key: TestAuthContext) -> WebCrawler:
+    """Provides a WebCrawler instance for document API testing."""
+    return WebCrawler(client, user_api_key=user_api_key)

--- a/backend/app/tests/api/routes/documents/test_route_document_info.py
+++ b/backend/app/tests/api/routes/documents/test_route_document_info.py
@@ -7,7 +7,6 @@ from app.tests.utils.document import (
     DocumentStore,
     Route,
     WebCrawler,
-    crawler,
     httpx_to_standard,
 )
 

--- a/backend/app/tests/api/routes/documents/test_route_document_list.py
+++ b/backend/app/tests/api/routes/documents/test_route_document_list.py
@@ -6,7 +6,6 @@ from app.tests.utils.document import (
     DocumentStore,
     Route,
     WebCrawler,
-    crawler,
     httpx_to_standard,
 )
 

--- a/backend/app/tests/api/routes/documents/test_route_document_permanent_remove.py
+++ b/backend/app/tests/api/routes/documents/test_route_document_permanent_remove.py
@@ -16,11 +16,10 @@ from app.core.cloud import AmazonCloudStorageClient
 from app.core.config import settings
 from app.models import Document
 from app.tests.utils.document import (
-    DocumentStore,
     DocumentMaker,
+    DocumentStore,
     Route,
     WebCrawler,
-    crawler,
 )
 
 

--- a/backend/app/tests/utils/document.py
+++ b/backend/app/tests/utils/document.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from dataclasses import dataclass
 from urllib.parse import ParseResult, urlunparse
 
-import pytest
 from httpx import Response
 from sqlmodel import Session, delete
 from fastapi.testclient import TestClient
@@ -164,8 +163,3 @@ class DocumentComparator:
             result[field] = self.to_string(value)
 
         return result
-
-
-@pytest.fixture
-def crawler(client: TestClient, user_api_key: TestAuthContext) -> WebCrawler:
-    return WebCrawler(client, user_api_key=user_api_key)


### PR DESCRIPTION
## Summary
The crawler fixture was being imported directly in test files, which linters flagged as an "unused import" since fixtures aren't explicitly called. This led to accidental removal and test failures. Moving the fixture to a conftest.py file follows pytest best practices for fixture discovery and avoids lint false positives
