### PR TITLE
Langfuse: question_id not in traces

### DIFF
--- a/backend/app/crud/evaluations/score.py
+++ b/backend/app/crud/evaluations/score.py
@@ -23,6 +23,7 @@ class TraceData(TypedDict):
     trace_id: str
     question: str
     llm_answer: str
+    question_id: int
     ground_truth_answer: str
     scores: list[TraceScore]
 

--- a/backend/app/crud/evaluations/score.py
+++ b/backend/app/crud/evaluations/score.py
@@ -23,7 +23,7 @@ class TraceData(TypedDict):
     trace_id: str
     question: str
     llm_answer: str
-    question_id: int
+    question_id: int | None
     ground_truth_answer: str
     scores: list[TraceScore]
 


### PR DESCRIPTION
Earlier `question_id` was not in the response for GET evaluations/{evaluation_id} endpoint.

In the `app/crud/evaluations/score.py`
```
class TraceData(TypedDict):
    """Data for a single trace including Q&A and scores."""

    trace_id: str
    question: str
    llm_answer: str
    **question_id: int | None**
    ground_truth_answer: str
    scores: list[TraceScore]
```
This pydantic model did not have `question_id` earlier, hence in the `fetch_trace_scores_from_langfuse` function where the model was used omitting the concerned key. 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trace data now includes optional question identifiers to enable finer-grained tracking, correlation, and filtering of evaluation results across runs and datasets.
  * Enhanced score retrieval: supports numeric and categorical scores, aggregates summary scores, and handles mixed/empty datasets and per-trace failures robustly.

* **Tests**
  * Added comprehensive tests covering score fetching, aggregation, filtering, and error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->