### PR TITLE
Standardize API endpoints by removing trailing slashes

### DIFF
--- a/backend/app/api/docs/documents/upload.md
+++ b/backend/app/api/docs/documents/upload.md
@@ -4,6 +4,12 @@ Upload a document to Kaapi.
 - If a target format is specified, a transformation job will also be created to transform document into target format in the background. The response will include both the uploaded document details and information about the transformation job.
 - If a callback URL is provided, you will receive a notification at that URL once the document transformation job is completed.
 
+### File Size Restrictions
+
+- **Maximum file size**: 50MB (configurable via `MAX_DOCUMENT_UPLOAD_SIZE_MB` environment variable)
+- Files exceeding the size limit will be rejected with a 413 (Payload Too Large) error
+- Empty files will be rejected with a 422 (Unprocessable Entity) error
+
 ### Supported Transformations
 
 The following (source_format → target_format) transformations are supported:

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -34,6 +34,7 @@ from app.services.documents.helpers import (
     build_document_schema,
     build_document_schemas,
 )
+from app.services.documents.validators import validate_document_file
 from app.utils import (
     APIResponse,
     get_openai_client,
@@ -122,6 +123,9 @@ async def upload_doc(
 ):
     if callback_url:
         validate_callback_url(callback_url)
+
+    # Validate file size before uploading to S3
+    await validate_document_file(src)
 
     source_format, actual_transformer = pre_transform_validation(
         src_filename=src.filename,

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -83,7 +83,7 @@ def recover_password(email: str, session: SessionDep) -> Message:
     return Message(message="Password recovery email sent")
 
 
-@router.post("/reset-password/", include_in_schema=False)
+@router.post("/reset-password", include_in_schema=False)
 def reset_password(session: SessionDep, body: NewPassword) -> Message:
     """
     Reset password

--- a/backend/app/api/routes/private.py
+++ b/backend/app/api/routes/private.py
@@ -20,7 +20,7 @@ class PrivateUserCreate(BaseModel):
     is_verified: bool = False
 
 
-@router.post("/users/", response_model=UserPublic, include_in_schema=False)
+@router.post("/users", response_model=UserPublic, include_in_schema=False)
 def create_user(user_in: PrivateUserCreate, session: SessionDep) -> Any:
     """
     Create a new user.

--- a/backend/app/api/routes/utils.py
+++ b/backend/app/api/routes/utils.py
@@ -27,6 +27,6 @@ def test_email(email_to: EmailStr) -> Message:
     return Message(message="Test email sent")
 
 
-@router.get("/health/", include_in_schema=False)
+@router.get("/health", include_in_schema=False)
 async def health_check() -> bool:
     return True

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -123,6 +123,9 @@ class Settings(BaseSettings):
     CALLBACK_CONNECT_TIMEOUT: int = 3
     CALLBACK_READ_TIMEOUT: int = 10
 
+    # Document upload size limit (in MB)
+    MAX_DOCUMENT_UPLOAD_SIZE_MB: int = 50
+
     @computed_field  # type: ignore[prop-decorator]
     @property
     def COMPUTED_CELERY_WORKER_CONCURRENCY(self) -> int:

--- a/backend/app/services/documents/validators.py
+++ b/backend/app/services/documents/validators.py
@@ -1,0 +1,54 @@
+"""Validation utilities for document uploads."""
+
+import logging
+from pathlib import Path
+
+from fastapi import HTTPException, UploadFile
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Maximum file size for document uploads (in bytes)
+# Default: 50 MB, configurable via settings
+MAX_DOCUMENT_SIZE = settings.MAX_DOCUMENT_UPLOAD_SIZE_MB * 1024 * 1024
+
+
+async def validate_document_file(file: UploadFile) -> int:
+    """
+    Validate document file size.
+
+    Args:
+        file: The uploaded file
+
+    Returns:
+        File size in bytes if valid
+
+    Raises:
+        HTTPException: If validation fails
+    """
+    if not file.filename:
+        raise HTTPException(
+            status_code=422,
+            detail="File must have a filename",
+        )
+
+    # Get file size by seeking to end
+    file.file.seek(0, 2)
+    file_size = file.file.tell()
+    file.file.seek(0)
+
+    if file_size > MAX_DOCUMENT_SIZE:
+        raise HTTPException(
+            status_code=413,
+            detail=f"File too large. Maximum size: {MAX_DOCUMENT_SIZE / (1024 * 1024):.0f}MB",
+        )
+
+    if file_size == 0:
+        raise HTTPException(
+            status_code=422,
+            detail="Empty file uploaded"
+        )
+
+    logger.info(f"Document file validated: {file.filename} ({file_size} bytes)")
+    return file_size

--- a/backend/app/tests/api/routes/test_login.py
+++ b/backend/app/tests/api/routes/test_login.py
@@ -72,7 +72,7 @@ def test_reset_password(client: TestClient, db: Session) -> None:
     data = {"new_password": new_password, "token": token}
 
     r = client.post(
-        f"{settings.API_V1_STR}/reset-password/",
+        f"{settings.API_V1_STR}/reset-password",
         headers=headers,
         json=data,
     )
@@ -89,7 +89,7 @@ def test_reset_password_invalid_token(
 ) -> None:
     data = {"new_password": "changethis", "token": "invalid"}
     r = client.post(
-        f"{settings.API_V1_STR}/reset-password/",
+        f"{settings.API_V1_STR}/reset-password",
         headers=superuser_token_headers,
         json=data,
     )

--- a/backend/app/tests/api/routes/test_private.py
+++ b/backend/app/tests/api/routes/test_private.py
@@ -7,7 +7,7 @@ from app.models import User
 
 def test_create_user(client: TestClient, db: Session) -> None:
     r = client.post(
-        f"{settings.API_V1_STR}/private/users/",
+        f"{settings.API_V1_STR}/private/users",
         json={
             "email": "pollo@listo.com",
             "password": "password123",


### PR DESCRIPTION
Fixes #561

### Summary
- Removed trailing slashes from API endpoints
- Updated tests to reflect the new endpoint format

### Motivation
Standardizing endpoint URLs improves consistency and avoids ambiguity for API clients.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file size validation for document uploads with a 50MB maximum limit (configurable). Oversized files are rejected with error 413; empty files return error 422.

* **API Improvements**
  * Removed trailing slashes from select endpoints for cleaner URL formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->