### PR TITLE
Evaluation: Router Fix

### DIFF
--- a/backend/app/api/routes/evaluations/__init__.py
+++ b/backend/app/api/routes/evaluations/__init__.py
@@ -7,6 +7,6 @@ from app.api.routes.stt_evaluations.router import router as stt_router
 
 router = APIRouter()
 
-router.include_router(evaluation.router)
 router.include_router(dataset.router)
 router.include_router(stt_router)
+router.include_router(evaluation.router)


### PR DESCRIPTION
## Summary

Target issue is #597

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Reorganized internal router configuration in the evaluations module.Previously, FastAPI was matching `/evaluations/datasets` against `/evaluations/{evaluation_id}`, interpreting "datasets" as the evaluation_id integer parameter, which caused the parse error.