### PR TITLE
API Docs: Add type field in the API docs for POST /config endpoint

### DIFF
--- a/backend/app/api/docs/config/create.md
+++ b/backend/app/api/docs/config/create.md
@@ -9,6 +9,7 @@ Configurations allow you to store and manage reusable LLM parameters
 * Stores provider-specific parameters as flexible JSON (config_blob)
 * Supports optional commit messages for tracking changes
 * Provider-agnostic storage - params are passed through to the provider as-is
+* Supports three types of config blob types; "text", "stt" and "tts".
 
 
 **Example for the config blob: OpenAI Responses API with File Search -**
@@ -17,6 +18,7 @@ Configurations allow you to store and manage reusable LLM parameters
 "config_blob": {
     "completion": {
       "provider": "openai",
+      "type":"text",
       "params": {
         "model": "gpt-4o-mini",
         "instructions": "You are a helpful assistant for farming communities...",
@@ -31,4 +33,5 @@ Configurations allow you to store and manage reusable LLM parameters
 
 The configuration name must be unique within your project. Once created,
 you can create additional versions to track parameter changes while
-maintaining the configuration history.
+maintaining the configuration history. Type "stt" and "tts" only applicable for Gemini models.
+Use type "text" if using OpenAI models.

--- a/backend/app/api/docs/config/create.md
+++ b/backend/app/api/docs/config/create.md
@@ -33,5 +33,5 @@ Configurations allow you to store and manage reusable LLM parameters
 
 The configuration name must be unique within your project. Once created,
 you can create additional versions to track parameter changes while
-maintaining the configuration history. Type "stt" and "tts" only applicable for Gemini models.
-Use type "text" if using OpenAI models.
+maintaining the configuration history. Type 'text' is applicable only for OpenAI models.
+Type "stt" and "tts" are only applicable for Gemini models.


### PR DESCRIPTION
## Summary

Target issue is #TBD
Add type field to the config creation API docs

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified three config blob types ("text", "stt", "tts") in API configuration docs.
  * Updated example to include "type":"text" and added model-specific guidance: "text" for OpenAI, "stt" and "tts" for Gemini.
  * Minor formatting and guidance updates to emphasize preserving configuration history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->