### PR TITLE
Config: Fix legacy configs missing completion type field

### DIFF
--- a/backend/app/alembic/versions/047_backfill_legacy_config_completion_type.py
+++ b/backend/app/alembic/versions/047_backfill_legacy_config_completion_type.py
@@ -1,0 +1,34 @@
+"""backfill legacy config completion type
+
+Revision ID: 047
+Revises: 046
+Create Date: 2026-02-17 00:00:00.000000
+
+"""
+from alembic import op
+
+revision = "047"
+down_revision = "046"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE config_version
+        SET config_blob = jsonb_set(config_blob, '{completion,type}', '"text"')
+        WHERE config_blob->'completion' IS NOT NULL
+          AND config_blob->'completion'->>'type' IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE config_version
+        SET config_blob = config_blob #- '{completion,type}'
+        WHERE config_blob->'completion'->>'type' = 'text'
+        """
+    )

--- a/backend/app/alembic/versions/047_backfill_legacy_config_completion_type.py
+++ b/backend/app/alembic/versions/047_backfill_legacy_config_completion_type.py
@@ -25,10 +25,5 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute(
-        """
-        UPDATE config_version
-        SET config_blob = config_blob #- '{completion,type}'
-        WHERE config_blob->'completion'->>'type' = 'text'
-        """
-    )
+    # No-op: removing type='text' would drop a required field and break validation; NULL safely defaults to 'text'.
+    pass

--- a/backend/app/crud/config/version.py
+++ b/backend/app/crud/config/version.py
@@ -156,6 +156,10 @@ class ConfigVersionCrud:
         existing_type = existing_completion.get("type")
         merged_type = merged_completion.get("type")
 
+        # Legacy configs predate the 'type' field; all were text-only
+        if existing_type is None:
+            existing_type = "text"
+
         if existing_type != merged_type:
             raise HTTPException(
                 status_code=400,
@@ -274,7 +278,11 @@ class ConfigVersionCrud:
             version_create.config_blob.model_dump().get("completion", {}).get("type")
         )
 
-        if old_type is None or new_type is None:
+        # Legacy configs predate the 'type' field; all were text-only
+        if old_type is None:
+            old_type = "text"
+
+        if new_type is None:
             logger.error(
                 f"[ConfigVersionCrud._validate_config_type_unchanged] Missing type field | "
                 f"{{'config_id': '{self.config_id}', 'old_type': {old_type}, 'new_type': {new_type}}}"

--- a/backend/app/tests/crud/config/test_version.py
+++ b/backend/app/tests/crud/config/test_version.py
@@ -4,7 +4,7 @@ import pytest
 from sqlmodel import Session
 from fastapi import HTTPException
 
-from app.models import ConfigVersionUpdate, ConfigBlob
+from app.models import ConfigVersionUpdate, ConfigBlob, ConfigVersionCreate
 from app.models.llm.request import NativeCompletionConfig
 from app.crud.config import ConfigVersionCrud
 from app.tests.utils.test_data import (
@@ -417,6 +417,149 @@ def test_create_version_different_configs(
     assert version2_config2.version == 2
     assert version2_config1.config_id == config1.id
     assert version2_config2.config_id == config2.id
+
+
+def test_validate_immutable_fields_legacy_config_allows_text_update(
+    db: Session, example_config_blob: ConfigBlob
+) -> None:
+    """Test that a legacy config (no type field) allows updates with type='text'."""
+    config = create_test_config(db)
+    version_crud = ConfigVersionCrud(
+        session=db, project_id=config.project_id, config_id=config.id
+    )
+
+    # Simulate a legacy config_blob without 'type' in completion
+    legacy_blob = {
+        "completion": {
+            "provider": "openai-native",
+            "params": {
+                "model": "gpt-4",
+                "temperature": 0.7,
+                "max_tokens": 1000,
+            },
+        }
+    }
+    merged_blob = {
+        "completion": {
+            "provider": "openai-native",
+            "type": "text",
+            "params": {
+                "model": "gpt-4",
+                "temperature": 0.8,
+                "max_tokens": 1500,
+            },
+        }
+    }
+
+    # Should NOT raise — legacy configs default to "text"
+    version_crud._validate_immutable_fields(legacy_blob, merged_blob)
+
+
+def test_validate_immutable_fields_legacy_config_rejects_non_text_update(
+    db: Session, example_config_blob: ConfigBlob
+) -> None:
+    """Test that a legacy config (no type field) rejects updates with type != 'text'."""
+    config = create_test_config(db)
+    version_crud = ConfigVersionCrud(
+        session=db, project_id=config.project_id, config_id=config.id
+    )
+
+    legacy_blob = {
+        "completion": {
+            "provider": "openai-native",
+            "params": {
+                "model": "gpt-4",
+                "temperature": 0.7,
+            },
+        }
+    }
+    merged_blob = {
+        "completion": {
+            "provider": "openai-native",
+            "type": "stt",
+            "params": {
+                "model": "gpt-4",
+                "temperature": 0.8,
+            },
+        }
+    }
+
+    with pytest.raises(
+        HTTPException,
+        match="Cannot change config type from 'text' to 'stt'",
+    ):
+        version_crud._validate_immutable_fields(legacy_blob, merged_blob)
+
+
+def test_validate_config_type_unchanged_legacy_config_allows_text(
+    db: Session,
+) -> None:
+    """Test that _validate_config_type_unchanged defaults legacy (null type) to 'text'."""
+    config = create_test_config(db)
+    version_crud = ConfigVersionCrud(
+        session=db, project_id=config.project_id, config_id=config.id
+    )
+
+    # Directly patch the latest version's config_blob to remove 'type' (simulate legacy)
+    latest_version = version_crud._get_latest_version()
+    blob = dict(latest_version.config_blob)
+    blob["completion"] = {k: v for k, v in blob["completion"].items() if k != "type"}
+    latest_version.config_blob = blob
+    db.add(latest_version)
+    db.commit()
+
+    # Creating a new version with type="text" should succeed
+    new_blob = ConfigBlob(
+        completion=NativeCompletionConfig(
+            provider="openai-native",
+            type="text",
+            params={"model": "gpt-4", "temperature": 0.8, "max_tokens": 1500},
+        )
+    )
+    version_create = ConfigVersionCreate(
+        config_blob=new_blob,
+        commit_message="Update after legacy",
+    )
+
+    # Should NOT raise
+    version_crud._validate_config_type_unchanged(version_create)
+
+
+def test_validate_config_type_unchanged_legacy_config_rejects_non_text(
+    db: Session,
+) -> None:
+    """Test that _validate_config_type_unchanged rejects non-text type for legacy configs."""
+    config = create_test_config(db)
+    version_crud = ConfigVersionCrud(
+        session=db, project_id=config.project_id, config_id=config.id
+    )
+
+    # Directly patch the latest version's config_blob to remove 'type' (simulate legacy)
+    latest_version = version_crud._get_latest_version()
+    blob = dict(latest_version.config_blob)
+    blob["completion"] = {k: v for k, v in blob["completion"].items() if k != "type"}
+    latest_version.config_blob = blob
+    db.add(latest_version)
+    db.commit()
+
+    # Creating a new version with type="stt" should fail
+    new_blob = ConfigBlob(
+        completion=NativeCompletionConfig(
+            provider="openai-native",
+            type="stt",
+            params={"model": "gpt-4", "temperature": 0.8, "max_tokens": 1500},
+        )
+    )
+    version_create = ConfigVersionCreate(
+        config_blob=new_blob,
+        commit_message="Change type after legacy",
+    )
+
+    with pytest.raises(
+        HTTPException,
+        match="Cannot change config type from 'text' to 'stt'",
+    ):
+        version_crud._validate_config_type_unchanged(version_create)
 
 
 def test_read_all_versions_config_not_found(db: Session) -> None:

--- a/backend/app/tests/crud/config/test_version.py
+++ b/backend/app/tests/crud/config/test_version.py
@@ -4,7 +4,7 @@ import pytest
 from sqlmodel import Session
 from fastapi import HTTPException
 
-from app.models import ConfigVersionUpdate, ConfigBlob, ConfigVersionCreate
+from app.models import ConfigVersionUpdate, ConfigBlob
 from app.models.llm.request import NativeCompletionConfig
 from app.crud.config import ConfigVersionCrud
 from app.tests.utils.test_data import (
@@ -489,77 +489,6 @@ def test_validate_immutable_fields_legacy_config_rejects_non_text_update(
         match="Cannot change config type from 'text' to 'stt'",
     ):
         version_crud._validate_immutable_fields(legacy_blob, merged_blob)
-
-
-def test_validate_config_type_unchanged_legacy_config_allows_text(
-    db: Session,
-) -> None:
-    """Test that _validate_config_type_unchanged defaults legacy (null type) to 'text'."""
-    config = create_test_config(db)
-    version_crud = ConfigVersionCrud(
-        session=db, project_id=config.project_id, config_id=config.id
-    )
-
-    # Directly patch the latest version's config_blob to remove 'type' (simulate legacy)
-    latest_version = version_crud._get_latest_version()
-    blob = dict(latest_version.config_blob)
-    blob["completion"] = {k: v for k, v in blob["completion"].items() if k != "type"}
-    latest_version.config_blob = blob
-    db.add(latest_version)
-    db.commit()
-
-    # Creating a new version with type="text" should succeed
-    new_blob = ConfigBlob(
-        completion=NativeCompletionConfig(
-            provider="openai-native",
-            type="text",
-            params={"model": "gpt-4", "temperature": 0.8, "max_tokens": 1500},
-        )
-    )
-    version_create = ConfigVersionCreate(
-        config_blob=new_blob,
-        commit_message="Update after legacy",
-    )
-
-    # Should NOT raise
-    version_crud._validate_config_type_unchanged(version_create)
-
-
-def test_validate_config_type_unchanged_legacy_config_rejects_non_text(
-    db: Session,
-) -> None:
-    """Test that _validate_config_type_unchanged rejects non-text type for legacy configs."""
-    config = create_test_config(db)
-    version_crud = ConfigVersionCrud(
-        session=db, project_id=config.project_id, config_id=config.id
-    )
-
-    # Directly patch the latest version's config_blob to remove 'type' (simulate legacy)
-    latest_version = version_crud._get_latest_version()
-    blob = dict(latest_version.config_blob)
-    blob["completion"] = {k: v for k, v in blob["completion"].items() if k != "type"}
-    latest_version.config_blob = blob
-    db.add(latest_version)
-    db.commit()
-
-    # Creating a new version with type="stt" should fail
-    new_blob = ConfigBlob(
-        completion=NativeCompletionConfig(
-            provider="openai-native",
-            type="stt",
-            params={"model": "gpt-4", "temperature": 0.8, "max_tokens": 1500},
-        )
-    )
-    version_create = ConfigVersionCreate(
-        config_blob=new_blob,
-        commit_message="Change type after legacy",
-    )
-
-    with pytest.raises(
-        HTTPException,
-        match="Cannot change config type from 'text' to 'stt'",
-    ):
-        version_crud._validate_config_type_unchanged(version_create)
 
 
 def test_read_all_versions_config_not_found(db: Session) -> None:


### PR DESCRIPTION
## Summary

Target issue is #605
Explain the **motivation** for making this change. What existing problem does the pull request solve?
To make the create new version for existing legacy config to support completion.type where it is null 

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of legacy configurations that lack type information by defaulting to "text" to allow safe merges and updates.
  * Fixed validation to reject unsupported type changes while preserving immutability semantics.

* **Chores**
  * Added a migration to backfill missing config type fields to "text" for existing legacy records.

* **Tests**
  * Added tests covering legacy config compatibility, backfill behavior, and validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->