### PR TITLE
STT: list and get files

### DIFF
--- a/backend/app/api/docs/stt_evaluation/get_audio.md
+++ b/backend/app/api/docs/stt_evaluation/get_audio.md
@@ -1,0 +1,3 @@
+Retrieve metadata for a specific audio file by its ID.
+
+Returns detailed information about an uploaded audio file, including its S3 location, size, content type, and timestamps. You get a pre-signed S3 URL for direct file access as well if you have set ``include_signed_url=True``.

--- a/backend/app/api/docs/stt_evaluation/list_audios.md
+++ b/backend/app/api/docs/stt_evaluation/list_audios.md
@@ -1,0 +1,3 @@
+List all audio files for the current project.
+
+Returns metadata for all uploaded audio files, including file IDs, filenames, sizes, and content types. You get a pre-signed S3 URL with all the files in the list for direct file access as well if you have set ``include_signed_url=True``.

--- a/backend/app/api/routes/stt_evaluations/files.py
+++ b/backend/app/api/routes/stt_evaluations/files.py
@@ -26,7 +26,7 @@ router = APIRouter()
     description=load_description("stt_evaluation/upload_audio.md"),
 )
 def upload_audio(
-    _session: SessionDep,
+    session: SessionDep,
     auth_context: AuthContextDep,
     file: UploadFile = File(..., description="Audio file to upload"),
 ) -> APIResponse[AudioUploadResponse]:
@@ -37,7 +37,7 @@ def upload_audio(
     )
 
     result = upload_audio_file(
-        session=_session,
+        session=session,
         file=file,
         organization_id=auth_context.organization_.id,
         project_id=auth_context.project_.id,
@@ -54,7 +54,7 @@ def upload_audio(
     description=load_description("stt_evaluation/list_audios.md"),
 )
 def list_audio(
-    _session: SessionDep,
+    session: SessionDep,
     auth_context: AuthContextDep,
     include_signed_url: bool = Query(
         False, description="Include a signed URL to access the audio file"
@@ -71,11 +71,11 @@ def list_audio(
     storage = None
     if include_signed_url:
         storage = get_cloud_storage(
-            session=_session, project_id=auth_context.project_.id
+            session=session, project_id=auth_context.project_.id
         )
 
     files = list_files(
-        session=_session,
+        session=session,
         organization_id=auth_context.organization_.id,
         project_id=auth_context.project_.id,
     )
@@ -95,7 +95,7 @@ def list_audio(
     description=load_description("stt_evaluation/get_audio.md"),
 )
 def get_audio(
-    _session: SessionDep,
+    session: SessionDep,
     auth_context: AuthContextDep,
     file_id: int,
     include_signed_url: bool = Query(
@@ -110,7 +110,7 @@ def get_audio(
     )
 
     file = get_file_by_id(
-        session=_session,
+        session=session,
         file_id=file_id,
         organization_id=auth_context.organization_.id,
         project_id=auth_context.project_.id,
@@ -122,7 +122,7 @@ def get_audio(
     storage = None
     if include_signed_url:
         storage = get_cloud_storage(
-            session=_session, project_id=auth_context.project_.id
+            session=session, project_id=auth_context.project_.id
         )
 
     result = build_file_schema(

--- a/backend/app/api/routes/stt_evaluations/files.py
+++ b/backend/app/api/routes/stt_evaluations/files.py
@@ -2,12 +2,15 @@
 
 import logging
 
-from fastapi import APIRouter, Depends, File, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, Query
 
 from app.api.deps import AuthContextDep, SessionDep
+from app.core.cloud import get_cloud_storage
 from app.api.permissions import Permission, require_permission
-from app.models.file import AudioUploadResponse
+from app.models.file import AudioUploadResponse, FilePublic
+from app.crud.file import get_file_by_id, list_files
 from app.services.stt_evaluations.audio import upload_audio_file
+from app.services.stt_evaluations.helpers import build_file_schema, build_file_schemas
 from app.utils import APIResponse, load_description
 
 logger = logging.getLogger(__name__)
@@ -23,7 +26,7 @@ router = APIRouter()
     description=load_description("stt_evaluation/upload_audio.md"),
 )
 def upload_audio(
-    session: SessionDep,
+    _session: SessionDep,
     auth_context: AuthContextDep,
     file: UploadFile = File(..., description="Audio file to upload"),
 ) -> APIResponse[AudioUploadResponse]:
@@ -34,10 +37,96 @@ def upload_audio(
     )
 
     result = upload_audio_file(
-        session=session,
+        session=_session,
         file=file,
         organization_id=auth_context.organization_.id,
         project_id=auth_context.project_.id,
+    )
+
+    return APIResponse.success_response(data=result)
+
+
+@router.get(
+    "/files",
+    response_model=APIResponse[list[FilePublic]],
+    dependencies=[Depends(require_permission(Permission.REQUIRE_PROJECT))],
+    summary="List audio files",
+    description=load_description("stt_evaluation/list_audios.md"),
+)
+def list_audio(
+    _session: SessionDep,
+    auth_context: AuthContextDep,
+    include_signed_url: bool = Query(
+        True, description="Include a signed URL to access the audio file"
+    ),
+) -> APIResponse[list[FilePublic]]:
+    """Get audio files per project if provided"""
+
+    logger.info(
+        f"[list_audio] Listing audio files | "
+        f"project_id: {auth_context.project_.id}, "
+        f"include_signed_url: {include_signed_url}"
+    )
+
+    storage = None
+    if include_signed_url:
+        storage = get_cloud_storage(
+            session=_session, project_id=auth_context.project_.id
+        )
+
+    files = list_files(
+        session=_session,
+        organization_id=auth_context.organization_.id,
+        project_id=auth_context.project_.id,
+    )
+
+    result = build_file_schemas(
+        files=files, include_signed_url=include_signed_url, storage=storage
+    )
+
+    return APIResponse.success_response(data=result)
+
+
+@router.get(
+    "/files/{file_id}",
+    response_model=APIResponse[FilePublic],
+    dependencies=[Depends(require_permission(Permission.REQUIRE_PROJECT))],
+    summary="Get audio file by ID",
+    description=load_description("stt_evaluation/get_audio.md"),
+)
+def get_audio(
+    _session: SessionDep,
+    auth_context: AuthContextDep,
+    file_id: int,
+    include_signed_url: bool = Query(
+        True, description="Include a signed URL to access the audio file"
+    ),
+) -> APIResponse[FilePublic]:
+    """Get a single audio file by ID with optional signed URL."""
+    logger.info(
+        f"[get_audio] Getting audio file | "
+        f"project_id: {auth_context.project_.id}, file_id: {file_id}, "
+        f"include__signed_url: {include_signed_url}"
+    )
+
+    file = get_file_by_id(
+        session=_session,
+        file_id=file_id,
+        organization_id=auth_context.organization_.id,
+        project_id=auth_context.project_.id,
+    )
+
+    if not file:
+        raise HTTPException(status_code=404, detail=f"File with ID {file_id} not found")
+
+    storage = None
+    if include_signed_url:
+        storage = get_cloud_storage(
+            session=_session, project_id=auth_context.project_.id
+        )
+
+    result = build_file_schema(
+        file=file, include_signed_url=include_signed_url, storage=storage
     )
 
     return APIResponse.success_response(data=result)

--- a/backend/app/api/routes/stt_evaluations/files.py
+++ b/backend/app/api/routes/stt_evaluations/files.py
@@ -57,7 +57,7 @@ def list_audio(
     _session: SessionDep,
     auth_context: AuthContextDep,
     include_signed_url: bool = Query(
-        True, description="Include a signed URL to access the audio file"
+        False, description="Include a signed URL to access the audio file"
     ),
 ) -> APIResponse[list[FilePublic]]:
     """Get audio files per project if provided"""
@@ -99,7 +99,7 @@ def get_audio(
     auth_context: AuthContextDep,
     file_id: int,
     include_signed_url: bool = Query(
-        True, description="Include a signed URL to access the audio file"
+        False, description="Include a signed URL to access the audio file"
     ),
 ) -> APIResponse[FilePublic]:
     """Get a single audio file by ID with optional signed URL."""

--- a/backend/app/api/routes/stt_evaluations/files.py
+++ b/backend/app/api/routes/stt_evaluations/files.py
@@ -106,7 +106,7 @@ def get_audio(
     logger.info(
         f"[get_audio] Getting audio file | "
         f"project_id: {auth_context.project_.id}, file_id: {file_id}, "
-        f"include__signed_url: {include_signed_url}"
+        f"include_signed_url: {include_signed_url}"
     )
 
     file = get_file_by_id(

--- a/backend/app/crud/file.py
+++ b/backend/app/crud/file.py
@@ -5,7 +5,7 @@ import logging
 from sqlmodel import Session, select
 
 from app.core.util import now
-from app.models.file import File
+from app.models.file import File, FileType
 
 
 logger = logging.getLogger(__name__)
@@ -144,6 +144,7 @@ def list_files(
     statement = select(File).where(
         File.organization_id == organization_id,
         File.project_id == project_id,
+        File.file_type == FileType.AUDIO.value,
     )
 
     return list(session.exec(statement).all())

--- a/backend/app/crud/file.py
+++ b/backend/app/crud/file.py
@@ -5,7 +5,8 @@ import logging
 from sqlmodel import Session, select
 
 from app.core.util import now
-from app.models.file import File, FileType
+from app.models.file import File
+
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +118,30 @@ def get_files_by_ids(
 
     statement = select(File).where(
         File.id.in_(file_ids),
+        File.organization_id == organization_id,
+        File.project_id == project_id,
+    )
+
+    return list(session.exec(statement).all())
+
+
+def list_files(
+    *,
+    session: Session,
+    organization_id: int,
+    project_id: int,
+) -> list[File]:
+    """Get all file records for an organization and project.
+
+    Args:
+        session: Database session
+        organization_id: Organization ID
+        project_id: Project ID
+
+    Returns:
+        list[File]: List of all file records found
+    """
+    statement = select(File).where(
         File.organization_id == organization_id,
         File.project_id == project_id,
     )

--- a/backend/app/models/file.py
+++ b/backend/app/models/file.py
@@ -92,16 +92,6 @@ class AudioUploadResponse(SQLModel):
     content_type: str = Field(..., description="MIME type of the audio file")
 
 
-class AudioUploadResponse(SQLModel):
-    """Response model for audio file upload."""
-
-    file_id: int = Field(..., description="ID of the created file record")
-    s3_url: str = Field(..., description="S3 URL of the uploaded audio file")
-    filename: str = Field(..., description="Original filename")
-    size_bytes: int = Field(..., description="File size in bytes")
-    content_type: str = Field(..., description="MIME type of the audio file")
-
-
 class FilePublic(SQLModel):
     """Public model for file responses."""
 

--- a/backend/app/models/file.py
+++ b/backend/app/models/file.py
@@ -92,11 +92,22 @@ class AudioUploadResponse(SQLModel):
     content_type: str = Field(..., description="MIME type of the audio file")
 
 
+class AudioUploadResponse(SQLModel):
+    """Response model for audio file upload."""
+
+    file_id: int = Field(..., description="ID of the created file record")
+    s3_url: str = Field(..., description="S3 URL of the uploaded audio file")
+    filename: str = Field(..., description="Original filename")
+    size_bytes: int = Field(..., description="File size in bytes")
+    content_type: str = Field(..., description="MIME type of the audio file")
+
+
 class FilePublic(SQLModel):
     """Public model for file responses."""
 
     id: int
     object_store_url: str
+    signed_url: str | None = None
     filename: str
     size_bytes: int
     content_type: str

--- a/backend/app/services/stt_evaluations/helpers.py
+++ b/backend/app/services/stt_evaluations/helpers.py
@@ -30,7 +30,7 @@ def build_file_schema(
             schema.signed_url = storage.get_signed_url(file.object_store_url)
         except Exception as e:
             logger.warning(
-                f"[build_file_schema] Failed to generate signed URL for file {file.id}: {e}"
+                f"[build_file_schema] Failed to generate signed URL for file {file.id}"
             )
             schema.signed_url = None
     return schema
@@ -60,7 +60,7 @@ def build_file_schemas(
                 schema.signed_url = storage.get_signed_url(file.object_store_url)
             except Exception as e:
                 logger.warning(
-                    f"[build_file_schemas] Failed to generate signed URL for file {file.id}: {e}"
+                    f"[build_file_schemas] Failed to generate signed URL for file {file.id}"
                 )
                 schema.signed_url = None
         out.append(schema)

--- a/backend/app/services/stt_evaluations/helpers.py
+++ b/backend/app/services/stt_evaluations/helpers.py
@@ -1,0 +1,67 @@
+"""Helper functions for building audio file response schemas with signed URLs."""
+
+import logging
+from typing import Iterable
+
+from app.models.file import File, FilePublic
+
+logger = logging.getLogger(__name__)
+
+
+def build_file_schema(
+    *,
+    file: File,
+    include_signed_url: bool,
+    storage: object | None,
+) -> FilePublic:
+    """Build a single file schema, optionally attaching a signed URL.
+
+    Args:
+        file: The File database model instance
+        include_url: Whether to generate and include a signed URL
+        storage: Cloud storage instance for generating signed URLs
+
+    Returns:
+        FilePublic schema with optional signed_url
+    """
+    schema = FilePublic.model_validate(file, from_attributes=True)
+    if include_signed_url and storage:
+        try:
+            schema.signed_url = storage.get_signed_url(file.object_store_url)
+        except Exception as e:
+            logger.warning(
+                f"[build_file_schema] Failed to generate signed URL for file {file.id}: {e}"
+            )
+            schema.signed_url = None
+    return schema
+
+
+def build_file_schemas(
+    *,
+    files: Iterable[File],
+    include_signed_url: bool,
+    storage: object | None,
+) -> list[FilePublic]:
+    """Build multiple file schemas efficiently, optionally attaching signed URLs.
+
+    Args:
+        files: Iterable of File database model instances
+        include_url: Whether to generate and include signed URLs
+        storage: Cloud storage instance for generating signed URLs
+
+    Returns:
+        List of FilePublic schemas with optional signed_url
+    """
+    out: list[FilePublic] = []
+    for file in files:
+        schema = FilePublic.model_validate(file, from_attributes=True)
+        if include_signed_url and storage:
+            try:
+                schema.signed_url = storage.get_signed_url(file.object_store_url)
+            except Exception as e:
+                logger.warning(
+                    f"[build_file_schemas] Failed to generate signed URL for file {file.id}: {e}"
+                )
+                schema.signed_url = None
+        out.append(schema)
+    return out

--- a/backend/app/tests/api/routes/test_stt_evaluation.py
+++ b/backend/app/tests/api/routes/test_stt_evaluation.py
@@ -1151,7 +1151,7 @@ class TestListAudioFiles:
     ) -> None:
         """Test listing audio files returns uploaded files."""
         # Create test audio files
-        file1 = create_test_file(
+        _ = create_test_file(
             db=db,
             organization_id=user_api_key.organization_id,
             project_id=user_api_key.project_id,
@@ -1159,7 +1159,7 @@ class TestListAudioFiles:
             object_store_url="s3://bucket/test1.mp3",
             file_type=FileType.AUDIO.value,
         )
-        file2 = create_test_file(
+        _ = create_test_file(
             db=db,
             organization_id=user_api_key.organization_id,
             project_id=user_api_key.project_id,

--- a/backend/app/tests/api/routes/test_stt_evaluation.py
+++ b/backend/app/tests/api/routes/test_stt_evaluation.py
@@ -1,4 +1,3 @@
-"""Tests for STT evaluation API routes."""
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -1122,3 +1121,379 @@ class TestSTTResultFeedback:
         )
 
         assert response.status_code == 401
+
+
+class TestListAudioFiles:
+    """Test GET /stt-evaluations/files endpoint."""
+
+    def test_list_audio_files_empty(
+        self,
+        client: TestClient,
+        user_api_key_header: dict[str, str],
+    ) -> None:
+        """Test listing audio files when none exist."""
+        response = client.get(
+            "/api/v1/evaluations/stt/files",
+            headers=user_api_key_header,
+        )
+
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data["success"] is True
+        assert isinstance(response_data["data"], list)
+
+    def test_list_audio_files_with_data(
+        self,
+        client: TestClient,
+        user_api_key_header: dict[str, str],
+        db: Session,
+        user_api_key: TestAuthContext,
+    ) -> None:
+        """Test listing audio files returns uploaded files."""
+        # Create test audio files
+        file1 = create_test_file(
+            db=db,
+            organization_id=user_api_key.organization_id,
+            project_id=user_api_key.project_id,
+            filename="test1.mp3",
+            object_store_url="s3://bucket/test1.mp3",
+            file_type=FileType.AUDIO.value,
+        )
+        file2 = create_test_file(
+            db=db,
+            organization_id=user_api_key.organization_id,
+            project_id=user_api_key.project_id,
+            filename="test2.wav",
+            object_store_url="s3://bucket/test2.wav",
+            file_type=FileType.AUDIO.value,
+        )
+
+        response = client.get(
+            "/api/v1/evaluations/stt/files",
+            headers=user_api_key_header,
+        )
+
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data["success"] is True
+        data = response_data["data"]
+
+        # Should have at least our 2 files
+        assert len(data) >= 2
+        filenames = [f["filename"] for f in data]
+        assert "test1.mp3" in filenames
+        assert "test2.wav" in filenames
+
+    @patch("app.api.routes.stt_evaluations.files.get_cloud_storage")
+    def test_list_audio_files_with_signed_urls(
+        self,
+        mock_get_cloud_storage: MagicMock,
+        client: TestClient,
+        user_api_key_header: dict[str, str],
+        db: Session,
+        user_api_key: TestAuthContext,
+    ) -> None:
+        """Test listing audio files includes signed URLs when requested."""
+        # Mock cloud storage
+        mock_storage = MagicMock()
+        mock_storage.get_signed_url.return_value = "https://signed.example.com/file.mp3"
+        mock_get_cloud_storage.return_value = mock_storage
+
+        # Create test file
+        file = create_test_file(
+            db=db,
+            organization_id=user_api_key.organization_id,
+            project_id=user_api_key.project_id,
+            filename="signed_url_test.mp3",
+            file_type=FileType.AUDIO.value,
+        )
+
+        response = client.get(
+            "/api/v1/evaluations/stt/files?include_signed_url=true",
+            headers=user_api_key_header,
+        )
+
+        assert response.status_code == 200
+        response_data = response.json()
+        data = response_data["data"]
+
+        # Find our test file
+        test_file = next(
+            (f for f in data if f["filename"] == "signed_url_test.mp3"), None
+        )
+        assert test_file is not None
+        assert test_file["signed_url"] == "https://signed.example.com/file.mp3"
+
+        # Verify cloud storage was called
+        mock_get_cloud_storage.assert_called_once()
+
+    def test_list_audio_files_without_signed_urls(
+        self,
+        client: TestClient,
+        user_api_key_header: dict[str, str],
+        db: Session,
+        user_api_key: TestAuthContext,
+    ) -> None:
+        """Test listing audio files without signed URLs."""
+        # Create test file
+        file = create_test_file(
+            db=db,
+            organization_id=user_api_key.organization_id,
+            project_id=user_api_key.project_id,
+            filename="no_signed_url.mp3",
+            file_type=FileType.AUDIO.value,
+        )
+
+        response = client.get(
+            "/api/v1/evaluations/stt/files?include_signed_url=false",
+            headers=user_api_key_header,
+        )
+
+        assert response.status_code == 200
+        response_data = response.json()
+        data = response_data["data"]
+
+        # All files should have None for signed_url
+        for f in data:
+            assert f["signed_url"] is None
+
+    def test_list_audio_files_project_isolation(
+        self,
+        client: TestClient,
+        user_api_key_header: dict[str, str],
+        superuser_api_key_header: dict[str, str],
+        db: Session,
+        user_api_key: TestAuthContext,
+    ) -> None:
+        """Test that audio files are isolated by project."""
+        # Create file in user's project
+        user_file = create_test_file(
+            db=db,
+            organization_id=user_api_key.organization_id,
+            project_id=user_api_key.project_id,
+            filename="user_project_file.mp3",
+            file_type=FileType.AUDIO.value,
+        )
+
+        # List files from superuser's project (different project)
+        response = client.get(
+            "/api/v1/evaluations/stt/files",
+            headers=superuser_api_key_header,
+        )
+
+        assert response.status_code == 200
+        response_data = response.json()
+        data = response_data["data"]
+
+        # Should not see user's file
+        filenames = [f["filename"] for f in data]
+        assert "user_project_file.mp3" not in filenames
+
+    def test_list_audio_files_requires_authentication(
+        self,
+        client: TestClient,
+    ) -> None:
+        """Test listing audio files without authentication fails."""
+        response = client.get("/api/v1/evaluations/stt/files")
+        assert response.status_code == 401
+
+
+class TestGetAudioFile:
+    """Test GET /stt-evaluations/files/{file_id} endpoint."""
+
+    def test_get_audio_file_success(
+        self,
+        client: TestClient,
+        user_api_key_header: dict[str, str],
+        db: Session,
+        user_api_key: TestAuthContext,
+    ) -> None:
+        """Test successfully getting an audio file by ID."""
+        # Create test file
+        file = create_test_file(
+            db=db,
+            organization_id=user_api_key.organization_id,
+            project_id=user_api_key.project_id,
+            filename="get_test.mp3",
+            object_store_url="s3://bucket/get_test.mp3",
+            size_bytes=2048,
+            content_type="audio/mp3",
+            file_type=FileType.AUDIO.value,
+        )
+
+        response = client.get(
+            f"/api/v1/evaluations/stt/files/{file.id}",
+            headers=user_api_key_header,
+        )
+
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data["success"] is True
+        data = response_data["data"]
+
+        assert data["id"] == file.id
+        assert data["filename"] == "get_test.mp3"
+        assert data["object_store_url"] == "s3://bucket/get_test.mp3"
+        assert data["size_bytes"] == 2048
+        assert data["content_type"] == "audio/mp3"
+        assert data["file_type"] == FileType.AUDIO.value
+        assert data["organization_id"] == user_api_key.organization_id
+        assert data["project_id"] == user_api_key.project_id
+
+    @patch("app.api.routes.stt_evaluations.files.get_cloud_storage")
+    def test_get_audio_file_with_signed_url(
+        self,
+        mock_get_cloud_storage: MagicMock,
+        client: TestClient,
+        user_api_key_header: dict[str, str],
+        db: Session,
+        user_api_key: TestAuthContext,
+    ) -> None:
+        """Test getting audio file includes signed URL when requested."""
+        # Mock cloud storage
+        mock_storage = MagicMock()
+        mock_storage.get_signed_url.return_value = (
+            "https://signed.example.com/audio.mp3"
+        )
+        mock_get_cloud_storage.return_value = mock_storage
+
+        # Create test file
+        file = create_test_file(
+            db=db,
+            organization_id=user_api_key.organization_id,
+            project_id=user_api_key.project_id,
+            filename="signed_url_get.mp3",
+            file_type=FileType.AUDIO.value,
+        )
+
+        response = client.get(
+            f"/api/v1/evaluations/stt/files/{file.id}?include_signed_url=true",
+            headers=user_api_key_header,
+        )
+
+        assert response.status_code == 200
+        response_data = response.json()
+        data = response_data["data"]
+
+        assert data["id"] == file.id
+        assert data["signed_url"] == "https://signed.example.com/audio.mp3"
+
+        # Verify cloud storage was called
+        mock_get_cloud_storage.assert_called_once()
+        mock_storage.get_signed_url.assert_called_once()
+
+    def test_get_audio_file_without_signed_url(
+        self,
+        client: TestClient,
+        user_api_key_header: dict[str, str],
+        db: Session,
+        user_api_key: TestAuthContext,
+    ) -> None:
+        """Test getting audio file without signed URL."""
+        # Create test file
+        file = create_test_file(
+            db=db,
+            organization_id=user_api_key.organization_id,
+            project_id=user_api_key.project_id,
+            filename="no_signed_url_get.mp3",
+            file_type=FileType.AUDIO.value,
+        )
+
+        response = client.get(
+            f"/api/v1/evaluations/stt/files/{file.id}?include_signed_url=false",
+            headers=user_api_key_header,
+        )
+
+        assert response.status_code == 200
+        response_data = response.json()
+        data = response_data["data"]
+
+        assert data["id"] == file.id
+        assert data["signed_url"] is None
+
+    def test_get_audio_file_not_found(
+        self,
+        client: TestClient,
+        user_api_key_header: dict[str, str],
+    ) -> None:
+        """Test getting non-existent audio file returns 404."""
+        response = client.get(
+            "/api/v1/evaluations/stt/files/99999",
+            headers=user_api_key_header,
+        )
+
+        assert response.status_code == 404
+        response_data = response.json()
+        error_str = response_data.get("error", response_data.get("detail", ""))
+        assert "not found" in error_str.lower()
+
+    def test_get_audio_file_wrong_project(
+        self,
+        client: TestClient,
+        user_api_key_header: dict[str, str],
+        superuser_api_key_header: dict[str, str],
+        db: Session,
+        user_api_key: TestAuthContext,
+    ) -> None:
+        """Test that users cannot access audio files from other projects."""
+        # Create file in user's project
+        file = create_test_file(
+            db=db,
+            organization_id=user_api_key.organization_id,
+            project_id=user_api_key.project_id,
+            filename="user_file.mp3",
+            file_type=FileType.AUDIO.value,
+        )
+
+        # Try to access from superuser's project
+        response = client.get(
+            f"/api/v1/evaluations/stt/files/{file.id}",
+            headers=superuser_api_key_header,
+        )
+
+        assert response.status_code == 404
+
+    def test_get_audio_file_requires_authentication(
+        self,
+        client: TestClient,
+    ) -> None:
+        """Test getting audio file without authentication fails."""
+        response = client.get("/api/v1/evaluations/stt/files/1")
+        assert response.status_code == 401
+
+    @patch("app.api.routes.stt_evaluations.files.get_cloud_storage")
+    def test_get_audio_file_signed_url_failure(
+        self,
+        mock_get_cloud_storage: MagicMock,
+        client: TestClient,
+        user_api_key_header: dict[str, str],
+        db: Session,
+        user_api_key: TestAuthContext,
+    ) -> None:
+        """Test getting audio file when signed URL generation fails."""
+        # Mock cloud storage to raise an exception
+        mock_storage = MagicMock()
+        mock_storage.get_signed_url.side_effect = Exception("S3 error")
+        mock_get_cloud_storage.return_value = mock_storage
+
+        # Create test file
+        file = create_test_file(
+            db=db,
+            organization_id=user_api_key.organization_id,
+            project_id=user_api_key.project_id,
+            filename="signed_url_fail.mp3",
+            file_type=FileType.AUDIO.value,
+        )
+
+        response = client.get(
+            f"/api/v1/evaluations/stt/files/{file.id}?include_signed_url=true",
+            headers=user_api_key_header,
+        )
+
+        # Should still succeed but with None for signed_url
+        assert response.status_code == 200
+        response_data = response.json()
+        data = response_data["data"]
+
+        assert data["id"] == file.id
+        assert data["signed_url"] is None


### PR DESCRIPTION
## Summary

Target issue is #656 

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

## Notes

* **New Features**
  * Added API endpoints to list all audio files and retrieve individual audio files from projects.
  * Added optional signed URL support for direct cloud storage access to audio files.
  * Improved error handling with proper responses when requested audio files are not found.

* **Tests**
  * Added comprehensive test coverage for new audio file listing and retrieval endpoints.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added endpoints to list all audio files and retrieve individual files from your project, including metadata such as file size and content type.
  * Optional signed URL generation for direct cloud storage access to audio files without additional authentication.

* **Documentation**
  * Added API documentation for audio file listing and retrieval endpoints with examples and response schemas.

* **Tests**
  * Comprehensive test coverage for new audio file management endpoints and signed URL functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->