### PR TITLE
STT Evaluation: Per sample language ID

### DIFF
--- a/backend/app/api/routes/stt_evaluations/dataset.py
+++ b/backend/app/api/routes/stt_evaluations/dataset.py
@@ -41,15 +41,14 @@ def create_dataset(
     dataset_create: STTDatasetCreate = Body(...),
 ) -> APIResponse[STTDatasetPublic]:
     """Create an STT evaluation dataset."""
-    # Validate language_id if provided
-    if dataset_create.language_id is not None:
-        language = get_language_by_id(
-            session=session, language_id=dataset_create.language_id
+    # Validate language_id
+    language = get_language_by_id(
+        session=session, language_id=dataset_create.language_id
+    )
+    if not language:
+        raise HTTPException(
+            status_code=400, detail="Invalid language_id: language not found"
         )
-        if not language:
-            raise HTTPException(
-                status_code=400, detail="Invalid language_id: language not found"
-            )
 
     dataset, samples = upload_stt_dataset(
         session=session,

--- a/backend/app/crud/stt_evaluations/dataset.py
+++ b/backend/app/crud/stt_evaluations/dataset.py
@@ -173,7 +173,9 @@ def create_stt_samples(
         STTSample(
             file_id=sample_data.file_id,
             ground_truth=sample_data.ground_truth,
-            language_id=dataset.language_id,
+            language_id=sample_data.language_id
+            if sample_data.language_id is not None
+            else dataset.language_id,
             sample_metadata={
                 "original_filename": file_map[sample_data.file_id].filename,
                 "file_extension": file_map[sample_data.file_id]

--- a/backend/app/crud/stt_evaluations/dataset.py
+++ b/backend/app/crud/stt_evaluations/dataset.py
@@ -28,7 +28,7 @@ def create_stt_dataset(
     org_id: int,
     project_id: int,
     description: str | None = None,
-    language_id: int = 1,
+    language_id: int | None = None,
     object_store_url: str | None = None,
     dataset_metadata: dict[str, Any] | None = None,
 ) -> EvaluationDataset:

--- a/backend/app/crud/stt_evaluations/dataset.py
+++ b/backend/app/crud/stt_evaluations/dataset.py
@@ -28,7 +28,7 @@ def create_stt_dataset(
     org_id: int,
     project_id: int,
     description: str | None = None,
-    language_id: int | None = None,
+    language_id: int = 1,
     object_store_url: str | None = None,
     dataset_metadata: dict[str, Any] | None = None,
 ) -> EvaluationDataset:

--- a/backend/app/models/stt_evaluation.py
+++ b/backend/app/models/stt_evaluation.py
@@ -280,8 +280,9 @@ class STTDatasetCreate(BaseModel):
 
     name: str = Field(..., description="Dataset name", min_length=1)
     description: str | None = Field(None, description="Dataset description")
-    language_id: int | None = Field(
-        None, description="ID of the language from global languages table"
+    language_id: int = Field(
+        1,
+        description="ID of the language from global languages table (default: English)",
     )
     samples: list[STTSampleCreate] = Field(
         ..., description="List of audio samples", min_length=1

--- a/backend/app/models/stt_evaluation.py
+++ b/backend/app/models/stt_evaluation.py
@@ -281,8 +281,7 @@ class STTDatasetCreate(BaseModel):
     name: str = Field(..., description="Dataset name", min_length=1)
     description: str | None = Field(None, description="Dataset description")
     language_id: int | None = Field(
-        None,
-        description="ID of the language from global languages table",
+        None, description="ID of the language from global languages table"
     )
     samples: list[STTSampleCreate] = Field(
         ..., description="List of audio samples", min_length=1

--- a/backend/app/models/stt_evaluation.py
+++ b/backend/app/models/stt_evaluation.py
@@ -280,9 +280,9 @@ class STTDatasetCreate(BaseModel):
 
     name: str = Field(..., description="Dataset name", min_length=1)
     description: str | None = Field(None, description="Dataset description")
-    language_id: int = Field(
-        1,
-        description="ID of the language from global languages table (default: English)",
+    language_id: int | None = Field(
+        None,
+        description="ID of the language from global languages table",
     )
     samples: list[STTSampleCreate] = Field(
         ..., description="List of audio samples", min_length=1

--- a/backend/app/models/stt_evaluation.py
+++ b/backend/app/models/stt_evaluation.py
@@ -221,6 +221,9 @@ class STTSampleCreate(BaseModel):
     ground_truth: str | None = Field(
         None, description="Reference transcription (optional)"
     )
+    language_id: int | None = Field(
+        None, description="Language ID for this sample (overrides dataset language)"
+    )
 
 
 class STTSamplePublic(BaseModel):

--- a/backend/app/services/stt_evaluations/dataset.py
+++ b/backend/app/services/stt_evaluations/dataset.py
@@ -28,7 +28,7 @@ def upload_stt_dataset(
     organization_id: int,
     project_id: int,
     description: str | None = None,
-    language_id: int = 1,
+    language_id: int | None = None,
 ) -> tuple[EvaluationDataset, list[STTSample]]:
     """
     Orchestrate STT dataset upload workflow.
@@ -46,7 +46,7 @@ def upload_stt_dataset(
         organization_id: Organization ID
         project_id: Project ID
         description: Optional dataset description
-        language_id: Language ID (default: 1, English)
+        language_id: Optional language ID
 
     Returns:
         Tuple of (created dataset, created samples)

--- a/backend/app/services/stt_evaluations/dataset.py
+++ b/backend/app/services/stt_evaluations/dataset.py
@@ -28,7 +28,7 @@ def upload_stt_dataset(
     organization_id: int,
     project_id: int,
     description: str | None = None,
-    language_id: int | None = None,
+    language_id: int = 1,
 ) -> tuple[EvaluationDataset, list[STTSample]]:
     """
     Orchestrate STT dataset upload workflow.
@@ -46,7 +46,7 @@ def upload_stt_dataset(
         organization_id: Organization ID
         project_id: Project ID
         description: Optional dataset description
-        language_id: Optional reference to global.languages table
+        language_id: Language ID (default: 1, English)
 
     Returns:
         Tuple of (created dataset, created samples)

--- a/backend/app/tests/api/routes/test_stt_evaluation.py
+++ b/backend/app/tests/api/routes/test_stt_evaluation.py
@@ -329,9 +329,7 @@ class TestSTTDatasetCreate:
 
         assert data["name"] == "minimal_stt_dataset"
         assert data["description"] is None
-        # Default language_id is 1 (English)
-        en_language = get_language_by_locale(session=db, locale="en")
-        assert data["language_id"] == en_language.id
+        assert data["language_id"] is None
         assert data["dataset_metadata"]["sample_count"] == 1
 
     def test_create_stt_dataset_empty_samples(

--- a/backend/app/tests/api/routes/test_stt_evaluation.py
+++ b/backend/app/tests/api/routes/test_stt_evaluation.py
@@ -216,6 +216,84 @@ class TestSTTDatasetCreate:
         assert data["dataset_metadata"]["sample_count"] == 2
         assert data["dataset_metadata"]["has_ground_truth_count"] == 1
 
+    def test_create_stt_dataset_with_per_sample_language_id(
+        self,
+        client: TestClient,
+        user_api_key_header: dict[str, str],
+        db: Session,
+        user_api_key: TestAuthContext,
+    ) -> None:
+        """Test creating an STT dataset with per-sample language_id overrides."""
+        en_language = get_language_by_locale(session=db, locale="en")
+        hi_language = get_language_by_locale(session=db, locale="hi")
+
+        file1 = create_test_file(
+            db=db,
+            organization_id=user_api_key.organization_id,
+            project_id=user_api_key.project_id,
+            object_store_url="s3://bucket/per_sample_lang_audio1.mp3",
+            filename="per_sample_lang_audio1.mp3",
+        )
+        file2 = create_test_file(
+            db=db,
+            organization_id=user_api_key.organization_id,
+            project_id=user_api_key.project_id,
+            object_store_url="s3://bucket/per_sample_lang_audio2.mp3",
+            filename="per_sample_lang_audio2.mp3",
+        )
+        file3 = create_test_file(
+            db=db,
+            organization_id=user_api_key.organization_id,
+            project_id=user_api_key.project_id,
+            object_store_url="s3://bucket/per_sample_lang_audio3.mp3",
+            filename="per_sample_lang_audio3.mp3",
+        )
+
+        response = client.post(
+            "/api/v1/evaluations/stt/datasets",
+            json={
+                "name": "per_sample_lang_dataset",
+                "language_id": en_language.id,
+                "samples": [
+                    {"file_id": file1.id, "ground_truth": "Hello"},
+                    {
+                        "file_id": file2.id,
+                        "ground_truth": "नमस्ते",
+                        "language_id": hi_language.id,
+                    },
+                    {"file_id": file3.id, "ground_truth": "World"},
+                ],
+            },
+            headers=user_api_key_header,
+        )
+
+        assert response.status_code == 200, response.text
+        response_data = response.json()
+        assert response_data["success"] is True
+        data = response_data["data"]
+
+        assert data["name"] == "per_sample_lang_dataset"
+        assert data["language_id"] == en_language.id
+        assert data["dataset_metadata"]["sample_count"] == 3
+
+        # Verify per-sample language_id by fetching dataset with samples
+        dataset_id = data["id"]
+        get_response = client.get(
+            f"/api/v1/evaluations/stt/datasets/{dataset_id}",
+            headers=user_api_key_header,
+        )
+        assert get_response.status_code == 200
+        get_data = get_response.json()["data"]
+        samples = get_data["samples"]
+
+        assert len(samples) == 3
+        # Sample without language_id -> inherits dataset's en
+        assert samples[0]["language_id"] == en_language.id
+        # Sample with explicit hi language_id
+        assert samples[1]["language_id"] == hi_language.id
+        # Sample without language_id -> inherits dataset's en
+        assert samples[2]["language_id"] == en_language.id
+
     def test_create_stt_dataset_minimal(
         self,
         client: TestClient,
@@ -251,7 +329,9 @@ class TestSTTDatasetCreate:
 
         assert data["name"] == "minimal_stt_dataset"
         assert data["description"] is None
-        assert data["language_id"] is None
+        # Default language_id is 1 (English)
+        en_language = get_language_by_locale(session=db, locale="en")
+        assert data["language_id"] == en_language.id
         assert data["dataset_metadata"]["sample_count"] == 1
 
     def test_create_stt_dataset_empty_samples(

--- a/backend/app/tests/crud/stt_evaluations/test_dataset.py
+++ b/backend/app/tests/crud/stt_evaluations/test_dataset.py
@@ -145,14 +145,13 @@ class TestCreateSTTSamplesLanguageId:
         # Third sample: no language_id specified -> inherits dataset's en
         assert created[2].language_id == en_language.id
 
-    def test_dataset_defaults_to_english_language(self, db: Session) -> None:
-        """Test that dataset defaults to English (language_id=1) when not specified."""
+    def test_dataset_defaults_to_none_language(self, db: Session) -> None:
+        """Test that dataset defaults to None language_id when not specified."""
         org = db.exec(select(Organization)).first()
         project = db.exec(
             select(Project).where(Project.organization_id == org.id)
         ).first()
 
-        en_language = get_language_by_locale(session=db, locale="en")
         file = create_test_file(db, org.id, project.id, filename="audio6.mp3")
 
         dataset = create_stt_dataset(
@@ -163,7 +162,7 @@ class TestCreateSTTSamplesLanguageId:
             dataset_metadata={"sample_count": 1, "has_ground_truth_count": 0},
         )
 
-        assert dataset.language_id == en_language.id
+        assert dataset.language_id is None
 
         samples = [
             STTSampleCreate(file_id=file.id, ground_truth="Hello"),
@@ -172,4 +171,4 @@ class TestCreateSTTSamplesLanguageId:
         created = create_stt_samples(session=db, dataset=dataset, samples=samples)
 
         assert len(created) == 1
-        assert created[0].language_id == en_language.id
+        assert created[0].language_id is None

--- a/backend/app/tests/crud/stt_evaluations/test_dataset.py
+++ b/backend/app/tests/crud/stt_evaluations/test_dataset.py
@@ -1,0 +1,175 @@
+"""Test cases for STT evaluation dataset CRUD operations."""
+
+from sqlmodel import Session, select
+
+from app.core.util import now
+from app.crud.language import get_language_by_locale
+from app.crud.stt_evaluations.dataset import create_stt_dataset, create_stt_samples
+from app.models import EvaluationDataset, Organization, Project, File, FileType
+from app.models.stt_evaluation import STTSampleCreate, EvaluationType
+
+
+def create_test_file(
+    db: Session,
+    organization_id: int,
+    project_id: int,
+    filename: str = "test.mp3",
+) -> File:
+    """Create a test file record."""
+    file = File(
+        object_store_url=f"s3://test-bucket/audio/{filename}",
+        filename=filename,
+        size_bytes=1024,
+        content_type="audio/mpeg",
+        file_type=FileType.AUDIO.value,
+        organization_id=organization_id,
+        project_id=project_id,
+        inserted_at=now(),
+        updated_at=now(),
+    )
+    db.add(file)
+    db.commit()
+    db.refresh(file)
+    return file
+
+
+class TestCreateSTTSamplesLanguageId:
+    """Test per-sample language_id override in create_stt_samples."""
+
+    def test_sample_inherits_dataset_language_when_not_specified(
+        self, db: Session
+    ) -> None:
+        """Test that samples inherit dataset language_id when sample language_id is None."""
+        org = db.exec(select(Organization)).first()
+        project = db.exec(
+            select(Project).where(Project.organization_id == org.id)
+        ).first()
+
+        language = get_language_by_locale(session=db, locale="en")
+
+        file = create_test_file(db, org.id, project.id, filename="audio1.mp3")
+
+        dataset = create_stt_dataset(
+            session=db,
+            name="dataset_with_lang",
+            org_id=org.id,
+            project_id=project.id,
+            language_id=language.id,
+            dataset_metadata={"sample_count": 1, "has_ground_truth_count": 0},
+        )
+
+        samples = [
+            STTSampleCreate(file_id=file.id, ground_truth="Hello"),
+        ]
+
+        created = create_stt_samples(session=db, dataset=dataset, samples=samples)
+
+        assert len(created) == 1
+        assert created[0].language_id == language.id
+
+    def test_sample_uses_own_language_when_specified(self, db: Session) -> None:
+        """Test that sample uses its own language_id when explicitly provided."""
+        org = db.exec(select(Organization)).first()
+        project = db.exec(
+            select(Project).where(Project.organization_id == org.id)
+        ).first()
+
+        en_language = get_language_by_locale(session=db, locale="en")
+        hi_language = get_language_by_locale(session=db, locale="hi")
+
+        file = create_test_file(db, org.id, project.id, filename="audio2.mp3")
+
+        dataset = create_stt_dataset(
+            session=db,
+            name="dataset_lang_override",
+            org_id=org.id,
+            project_id=project.id,
+            language_id=en_language.id,
+            dataset_metadata={"sample_count": 1, "has_ground_truth_count": 0},
+        )
+
+        samples = [
+            STTSampleCreate(
+                file_id=file.id,
+                ground_truth="नमस्ते",
+                language_id=hi_language.id,
+            ),
+        ]
+
+        created = create_stt_samples(session=db, dataset=dataset, samples=samples)
+
+        assert len(created) == 1
+        assert created[0].language_id == hi_language.id
+        assert created[0].language_id != en_language.id
+
+    def test_mixed_samples_with_and_without_language_id(self, db: Session) -> None:
+        """Test mix of samples: some with language_id, some inheriting from dataset."""
+        org = db.exec(select(Organization)).first()
+        project = db.exec(
+            select(Project).where(Project.organization_id == org.id)
+        ).first()
+
+        en_language = get_language_by_locale(session=db, locale="en")
+        hi_language = get_language_by_locale(session=db, locale="hi")
+
+        file1 = create_test_file(db, org.id, project.id, filename="audio3.mp3")
+        file2 = create_test_file(db, org.id, project.id, filename="audio4.mp3")
+        file3 = create_test_file(db, org.id, project.id, filename="audio5.mp3")
+
+        dataset = create_stt_dataset(
+            session=db,
+            name="dataset_mixed_lang",
+            org_id=org.id,
+            project_id=project.id,
+            language_id=en_language.id,
+            dataset_metadata={"sample_count": 3, "has_ground_truth_count": 0},
+        )
+
+        samples = [
+            STTSampleCreate(file_id=file1.id, ground_truth="Hello"),
+            STTSampleCreate(
+                file_id=file2.id,
+                ground_truth="नमस्ते",
+                language_id=hi_language.id,
+            ),
+            STTSampleCreate(file_id=file3.id, ground_truth="World"),
+        ]
+
+        created = create_stt_samples(session=db, dataset=dataset, samples=samples)
+
+        assert len(created) == 3
+        # First sample: no language_id specified -> inherits dataset's en
+        assert created[0].language_id == en_language.id
+        # Second sample: explicit hi language_id -> uses hi
+        assert created[1].language_id == hi_language.id
+        # Third sample: no language_id specified -> inherits dataset's en
+        assert created[2].language_id == en_language.id
+
+    def test_dataset_defaults_to_english_language(self, db: Session) -> None:
+        """Test that dataset defaults to English (language_id=1) when not specified."""
+        org = db.exec(select(Organization)).first()
+        project = db.exec(
+            select(Project).where(Project.organization_id == org.id)
+        ).first()
+
+        en_language = get_language_by_locale(session=db, locale="en")
+        file = create_test_file(db, org.id, project.id, filename="audio6.mp3")
+
+        dataset = create_stt_dataset(
+            session=db,
+            name="dataset_default_lang",
+            org_id=org.id,
+            project_id=project.id,
+            dataset_metadata={"sample_count": 1, "has_ground_truth_count": 0},
+        )
+
+        assert dataset.language_id == en_language.id
+
+        samples = [
+            STTSampleCreate(file_id=file.id, ground_truth="Hello"),
+        ]
+
+        created = create_stt_samples(session=db, dataset=dataset, samples=samples)
+
+        assert len(created) == 1
+        assert created[0].language_id == en_language.id

--- a/backend/app/tests/services/stt_evaluations/test_dataset.py
+++ b/backend/app/tests/services/stt_evaluations/test_dataset.py
@@ -13,6 +13,36 @@ from app.services.stt_evaluations.dataset import (
 )
 
 
+class TestSTTSampleCreateModel:
+    """Test cases for STTSampleCreate model with language_id field."""
+
+    def test_sample_create_without_language_id(self):
+        """Test creating STTSampleCreate without language_id defaults to None."""
+        sample = STTSampleCreate(file_id=1)
+        assert sample.language_id is None
+
+    def test_sample_create_with_language_id(self):
+        """Test creating STTSampleCreate with explicit language_id."""
+        sample = STTSampleCreate(file_id=1, language_id=42)
+        assert sample.language_id == 42
+
+    def test_sample_create_with_none_language_id(self):
+        """Test creating STTSampleCreate with explicit None language_id."""
+        sample = STTSampleCreate(file_id=1, language_id=None)
+        assert sample.language_id is None
+
+    def test_sample_create_with_all_fields(self):
+        """Test creating STTSampleCreate with all fields populated."""
+        sample = STTSampleCreate(
+            file_id=1,
+            ground_truth="Hello world",
+            language_id=5,
+        )
+        assert sample.file_id == 1
+        assert sample.ground_truth == "Hello world"
+        assert sample.language_id == 5
+
+
 class TestSamplesToCSV:
     """Test cases for _samples_to_csv function."""
 


### PR DESCRIPTION
## Summary

Target issue is #658

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sample-level language override: individual STT samples can specify a language that overrides the dataset default for mixed-language datasets.

* **Behavior Change**
  * Dataset language now defaults to English when not provided.

* **Bug Fixes**
  * Validation now rejects invalid language selections before upload.

* **Tests**
  * Added tests covering per-sample overrides, default behavior, and validation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->