### PR TITLE
Fix validation error related to versioning

### DIFF
--- a/backend/app/core/exception_handlers.py
+++ b/backend/app/core/exception_handlers.py
@@ -18,10 +18,11 @@ def _is_branch_identifier(part: str) -> bool:
     return bool(part and isinstance(part, str) and _BRANCH_PATTERN.search(part))
 
 
-def _filter_union_branch_errors(errors: list[dict]) -> list[dict]:
-    """When a field is a Union type, pydantic returns errors for every possible branch.
+def _sanitize_validation_errors(errors: list[dict]) -> list[dict]:
+    """Sanitize pydantic validation errors.
 
-    This function picks the branch where the validation error happend.
+    Filters union branch noise (keeps only the relevant branch),
+    strips internal fields, returning only loc, msg, and type.
     """
     try:
         branch_errors: dict[str, dict[str, list[dict]]] = defaultdict(
@@ -74,7 +75,11 @@ def _filter_union_branch_errors(errors: list[dict]) -> list[dict]:
                 seen_errors.add(error_key)
                 unique_errors.append(error)
 
-        return unique_errors or errors
+        sanitized = [
+            {k: v for k, v in err.items() if k in ("loc", "msg", "type")}
+            for err in (unique_errors or errors)
+        ]
+        return sanitized
     except Exception:
         return errors
 
@@ -84,7 +89,7 @@ def register_exception_handlers(app: FastAPI) -> None:
     async def validation_error_handler(
         request: Request, exc: RequestValidationError
     ) -> JSONResponse:
-        errors = _filter_union_branch_errors(exc.errors())
+        errors = _sanitize_validation_errors(exc.errors())
         return JSONResponse(
             status_code=HTTP_422_UNPROCESSABLE_ENTITY,
             content=APIResponse.failure_response(errors).model_dump(),
@@ -96,7 +101,7 @@ def register_exception_handlers(app: FastAPI) -> None:
     ) -> JSONResponse:
         detail = exc.detail
         if isinstance(detail, list):
-            detail = _filter_union_branch_errors(detail)
+            detail = _sanitize_validation_errors(detail)
         return JSONResponse(
             status_code=exc.status_code,
             content=APIResponse.failure_response(detail).model_dump(),

--- a/backend/app/core/exception_handlers.py
+++ b/backend/app/core/exception_handlers.py
@@ -94,9 +94,12 @@ def register_exception_handlers(app: FastAPI) -> None:
     async def http_exception_handler(
         request: Request, exc: HTTPException
     ) -> JSONResponse:
+        detail = exc.detail
+        if isinstance(detail, list):
+            detail = _filter_union_branch_errors(detail)
         return JSONResponse(
             status_code=exc.status_code,
-            content=APIResponse.failure_response(exc.detail).model_dump(),
+            content=APIResponse.failure_response(detail).model_dump(),
         )
 
     @app.exception_handler(Exception)

--- a/backend/app/crud/config/version.py
+++ b/backend/app/crud/config/version.py
@@ -68,10 +68,7 @@ class ConfigVersionCrud:
                 f"[ConfigVersionCrud.create_from_partial] Validation failed | "
                 f"{{'config_id': '{self.config_id}', 'error': '{str(e)}'}}"
             )
-            raise HTTPException(
-                status_code=400,
-                detail=f"Invalid config after merge: {str(e)}",
-            )
+            raise HTTPException(status_code=400, detail=e.errors())
 
         try:
             next_version = self._get_next_version(self.config_id)

--- a/backend/app/crud/config/version.py
+++ b/backend/app/crud/config/version.py
@@ -64,12 +64,13 @@ class ConfigVersionCrud:
         try:
             validated_blob = ConfigBlob.model_validate(merged_config)
         except ValidationError as e:
+            validation_errors = e.errors()
             logger.error(
                 f"[ConfigVersionCrud.create_or_raise] Validation failed | "
-                f"{{'config_id': '{self.config_id}', 'error_count': {len(e.errors())}, "
-                f"'fields': {['.'.join(str(l) for l in err['loc']) for err in e.errors()]}}}"
+                f"{{'config_id': '{self.config_id}', 'error_count': {len(validation_errors)}, "
+                f"'fields': {['.'.join(str(part) for part in err['loc']) for err in validation_errors]}}}"
             )
-            raise HTTPException(status_code=400, detail=e.errors())
+            raise HTTPException(status_code=400, detail=validation_errors)
 
         try:
             next_version = self._get_next_version(self.config_id)

--- a/backend/app/crud/config/version.py
+++ b/backend/app/crud/config/version.py
@@ -65,8 +65,9 @@ class ConfigVersionCrud:
             validated_blob = ConfigBlob.model_validate(merged_config)
         except ValidationError as e:
             logger.error(
-                f"[ConfigVersionCrud.create_from_partial] Validation failed | "
-                f"{{'config_id': '{self.config_id}', 'error': '{str(e)}'}}"
+                f"[ConfigVersionCrud.create_or_raise] Validation failed | "
+                f"{{'config_id': '{self.config_id}', 'error_count': {len(e.errors())}, "
+                f"'fields': {['.'.join(str(l) for l in err['loc']) for err in e.errors()]}}}"
             )
             raise HTTPException(status_code=400, detail=e.errors())
 

--- a/backend/app/tests/core/test_exception_handlers.py
+++ b/backend/app/tests/core/test_exception_handlers.py
@@ -1,18 +1,18 @@
 from fastapi.testclient import TestClient
 
 from app.core.config import settings
-from app.core.exception_handlers import _filter_union_branch_errors
+from app.core.exception_handlers import _sanitize_validation_errors
 from app.tests.utils.auth import TestAuthContext
 
 
-class TestFilterUnionBranchErrors:
-    """Unit tests for _filter_union_branch_errors."""
+class TestSanitizeValidationErrors:
+    """Unit tests for _sanitize_validation_errors."""
 
     def test_non_union_errors_pass_through(self) -> None:
         errors = [
             {"type": "missing", "loc": ("body", "name"), "msg": "Field required"},
         ]
-        assert _filter_union_branch_errors(errors) == errors
+        assert _sanitize_validation_errors(errors) == errors
 
     def test_picks_branch_with_fewer_literal_errors(self) -> None:
         errors = [
@@ -37,7 +37,7 @@ class TestFilterUnionBranchErrors:
                 "msg": "Field required",
             },
         ]
-        result = _filter_union_branch_errors(errors)
+        result = _sanitize_validation_errors(errors)
         assert len(result) == 2
         for err in result:
             assert "NativeConfig" not in err["loc"]
@@ -56,7 +56,7 @@ class TestFilterUnionBranchErrors:
                 "msg": "Field required",
             },
         ]
-        result = _filter_union_branch_errors(errors)
+        result = _sanitize_validation_errors(errors)
         assert len(result) == 1
         assert result[0]["loc"] == ("body", "c", "x")
 
@@ -74,7 +74,7 @@ class TestFilterUnionBranchErrors:
                 "msg": "Field required",
             }
         ]
-        result = _filter_union_branch_errors(errors)
+        result = _sanitize_validation_errors(errors)
         assert result[0]["loc"] == ("body", "cfg", "completion", "params")
 
     def test_non_union_preserved_with_union(self) -> None:
@@ -91,17 +91,17 @@ class TestFilterUnionBranchErrors:
                 "msg": "Field required",
             },
         ]
-        result = _filter_union_branch_errors(errors)
+        result = _sanitize_validation_errors(errors)
         assert len(result) == 2
         locs = [r["loc"] for r in result]
         assert ("body", "name") in locs
 
     def test_empty_list(self) -> None:
-        assert _filter_union_branch_errors([]) == []
+        assert _sanitize_validation_errors([]) == []
 
     def test_fallback_on_malformed_input(self) -> None:
         malformed = [None, 42]  # type: ignore[list-item]
-        result = _filter_union_branch_errors(malformed)
+        result = _sanitize_validation_errors(malformed)
         assert result == malformed
 
 


### PR DESCRIPTION
## Summary

Target issue is #688 
Explain the **motivation** for making this change. What existing problem does the pull request solve?

**The Version Create API raises validation errors as str(e) instead of e.errors(), causing the exception handler to return unstructured raw error responses instead of properly formatted ones.**
*like this below:*
```
{
    "success": false,
    "data": null,
    "error": "Invalid config after merge: 2 validation errors for ConfigBlob\ncompletion.NativeCompletionConfig.provider\n  Input should be 'openai-native', 'google-native', 'sarvamai-native' or 'elevenlabs-native' [type=literal_error, input_value='something', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.12/v/literal_error\ncompletion.function-after[validate_params(), KaapiCompletionConfig].provider\n  Input should be 'openai', 'google', 'sarvamai' or 'elevenlabs' [type=literal_error, input_value='something', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.12/v/literal_error",
    "errors": null,
    "metadata": null
}
```

Now it raises the error like this after fix
```
{
    "success": false,
    "data": null,
    "error": "Validation failed",
    "errors": [
        {
            "field": "completion.provider",
            "message": "Input should be 'openai-native', 'google-native', 'sarvamai-native' or 'elevenlabs-native'"
        },
        {
            "field": "completion.provider",
            "message": "Input should be 'openai', 'google', 'sarvamai' or 'elevenlabs'"
        }
    ],
    "metadata": null
}
```

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation errors in HTTP responses are now sanitized and compressed for clearer, more concise error messages when multiple details are present.
  * Configuration validation failures now return structured validation details (including failure counts and failing fields) to make diagnosis and resolution easier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->