### PR TITLE
Collections: batch size default to 10

### DIFF
--- a/backend/app/api/docs/collections/create.md
+++ b/backend/app/api/docs/collections/create.md
@@ -3,6 +3,9 @@ pipeline:
 
 * Create a vector store from the document IDs you received after uploading your
   documents through the Documents module.
+* The `batch_size` parameter controls how many documents are sent to OpenAI in a
+  single transaction when creating the vector store. This helps optimize the upload
+  process for large document sets. If not specified, the default value is **10**.
 * [Deprecated] Attach the Vector Store to an OpenAI
   [Assistant](https://platform.openai.com/docs/api-reference/assistants). Use
   parameters in the request body relevant to an Assistant to flesh out

--- a/backend/app/models/collection.py
+++ b/backend/app/models/collection.py
@@ -103,7 +103,7 @@ class CollectionOptions(SQLModel):
         description="List of document IDs",
     )
     batch_size: int = Field(
-        default=1,
+        default=10,
         description=(
             "Number of documents to send to OpenAI in a single "
             "transaction. See the `file_ids` parameter in the "

--- a/backend/app/services/collections/providers/openai.py
+++ b/backend/app/services/collections/providers/openai.py
@@ -30,10 +30,12 @@ class OpenAIProvider(BaseProvider):
         Create OpenAI vector store with documents and optionally an assistant.
         """
         try:
+            # Use user-provided batch_size, default to 10 if not set
+            batch_size = collection_request.batch_size or 10
             docs_batches = batch_documents(
                 document_crud,
                 collection_request.documents,
-                collection_request.batch_size,
+                batch_size,
             )
 
             vector_store_crud = OpenAIVectorStoreCrud(self.client)

--- a/backend/app/tests/api/routes/collections/test_create_collections.py
+++ b/backend/app/tests/api/routes/collections/test_create_collections.py
@@ -26,7 +26,7 @@ def test_collection_creation_with_assistant_calls_start_job_and_returns_job(
         instructions="string",
         temperature=0.000001,
         documents=[UUID("f3e86a17-1e6f-41ec-b020-5b08eebef928")],
-        batch_size=1,
+        batch_size=10,
         callback_url=None,
     )
 
@@ -71,7 +71,7 @@ def test_collection_creation_vector_only_adds_metadata_and_sets_with_assistant_f
     creation_data = CreationRequest(
         temperature=0.000001,
         documents=[str(uuid4())],
-        batch_size=1,
+        batch_size=10,
         callback_url=None,
     )
 
@@ -109,7 +109,7 @@ def test_collection_creation_vector_only_request_validation_error(
         "model": "gpt-4o",
         "temperature": 0.000001,
         "documents": [str(uuid4())],
-        "batch_size": 1,
+        "batch_size": 10,
         "callback_url": None,
     }
 

--- a/backend/app/tests/services/collections/providers/test_openai_provider.py
+++ b/backend/app/tests/services/collections/providers/test_openai_provider.py
@@ -18,7 +18,7 @@ def test_create_openai_vector_store_only() -> None:
 
     collection_request = SimpleNamespace(
         documents=["doc1", "doc2"],
-        batch_size=1,
+        batch_size=10,
         model=None,
         instructions=None,
         temperature=None,
@@ -57,7 +57,7 @@ def test_create_openai_with_assistant() -> None:
 
     collection_request = SimpleNamespace(
         documents=["doc1"],
-        batch_size=1,
+        batch_size=10,
         model="gpt-4o",
         instructions="You are helpful",
         temperature=0.7,
@@ -138,7 +138,7 @@ def test_create_propagates_exception() -> None:
 
     collection_request = SimpleNamespace(
         documents=["doc1"],
-        batch_size=1,
+        batch_size=10,
         model=None,
         instructions=None,
         temperature=None,

--- a/backend/app/tests/services/collections/test_create_collection.py
+++ b/backend/app/tests/services/collections/test_create_collection.py
@@ -58,7 +58,7 @@ def test_start_job_creates_collection_job_and_schedules_task(db: Session) -> Non
     project = get_project(db)
     request = CreationRequest(
         documents=[UUID("f3e86a17-1e6f-41ec-b020-5b08eebef928")],
-        batch_size=1,
+        batch_size=10,
         callback_url=None,
         provider="openai",
     )
@@ -137,7 +137,7 @@ def test_execute_job_success_flow_updates_job_and_creates_collection(
     aws.client.put_object(Bucket=settings.AWS_S3_BUCKET, Key=str(s3_key), Body=b"test")
 
     sample_request = CreationRequest(
-        documents=[document.id], batch_size=1, callback_url=None, provider="openai"
+        documents=[document.id], batch_size=10, callback_url=None, provider="openai"
     )
 
     mock_get_llm_provider.return_value = get_mock_provider(
@@ -205,7 +205,7 @@ def test_execute_job_assistant_create_failure_marks_failed_and_deletes_collectio
     )
 
     req = CreationRequest(
-        documents=[], batch_size=1, callback_url=None, provider="openai"
+        documents=[], batch_size=10, callback_url=None, provider="openai"
     )
 
     mock_provider = get_mock_provider(
@@ -269,7 +269,7 @@ def test_execute_job_success_flow_callback_job_and_creates_collection(
 
     sample_request = CreationRequest(
         documents=[document.id],
-        batch_size=1,
+        batch_size=10,
         callback_url=callback_url,
         provider="openai",
     )
@@ -350,7 +350,7 @@ def test_execute_job_success_creates_collection_with_callback(
 
     sample_request = CreationRequest(
         documents=[document.id],
-        batch_size=1,
+        0,
         callback_url=callback_url,
         provider="openai",
     )
@@ -434,7 +434,7 @@ def test_execute_job_failure_flow_callback_job_and_marks_failed(
 
     sample_request = CreationRequest(
         documents=[uuid.uuid4()],
-        batch_size=1,
+        batch_size=10,
         callback_url=callback_url,
         provider="openai",
     )

--- a/backend/app/tests/services/collections/test_create_collection.py
+++ b/backend/app/tests/services/collections/test_create_collection.py
@@ -350,7 +350,7 @@ def test_execute_job_success_creates_collection_with_callback(
 
     sample_request = CreationRequest(
         documents=[document.id],
-        0,
+        batch_size=10,
         callback_url=callback_url,
         provider="openai",
     )


### PR DESCRIPTION
## Summary

Target issue is #690 

## Notes

* **Documentation**
  * Added documentation explaining the batch_size parameter that controls document batching during collection creation, helping optimize performance for large uploads.

* **Enhancements**
  * Updated the default batch size from 1 to 10, improving efficiency when processing large document uploads.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive documentation for the batch_size parameter, describing how it controls the number of documents sent per transaction during vector store creation and highlighting optimization benefits for large uploads.

* **Improvements**
  * Optimized default batch size for document processing from 1 to 10 documents per transaction to improve upload performance for large datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->