### PR TITLE
Gemini STT: add latest google models for STT

### DIFF
--- a/backend/app/models/llm/constants.py
+++ b/backend/app/models/llm/constants.py
@@ -3,7 +3,12 @@ DEFAULT_TTS_MODEL = "gemini-2.5-flash-preview-tts"
 DEFAULT_TTS_VOICE = "Kore"
 
 SUPPORTED_MODELS = {
-    ("google", "stt"): [DEFAULT_STT_MODEL],
+    ("google", "stt"): [
+        DEFAULT_STT_MODEL,
+        "gemini-3.1-pro-preview",
+        "gemini-3-flash-preview",
+        "gemini-2.5-flash",
+    ],
     ("google", "tts"): [DEFAULT_TTS_MODEL, "gemini-2.5-pro-preview-tts"],
     ("sarvamai", "stt"): ["saaras:v3"],
     ("sarvamai", "tts"): ["bulbul:v3"],


### PR DESCRIPTION
## Summary

Target issue is #764 
Added support for "gemini-2.5-flash", "gemini-3.1-pro-preview", "gemini-3-flash-preview" as optional models for Google alongside default gemini-2.5.-pro

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.
