### PR TITLE
Docker: Hotfix ENV variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,8 +91,6 @@ services:
     command: bash scripts/prestart.sh
     env_file:
       - .env
-    environment:
-      POSTGRES_SERVER: db
     profiles: ["prestart"]
 
   backend:
@@ -111,7 +109,6 @@ services:
     env_file:
       - .env
     environment:
-      POSTGRES_SERVER: db
       REDIS_HOST: redis
       RABBITMQ_HOST: rabbitmq
     ports:
@@ -147,7 +144,6 @@ services:
     env_file:
       - .env
     environment:
-      POSTGRES_SERVER: db
       REDIS_HOST: redis
       RABBITMQ_HOST: rabbitmq
     command: ["uv", "run", "celery", "-A", "app.celery.celery_app", "worker", "--loglevel=info"]
@@ -166,7 +162,6 @@ services:
     ports:
       - "5555:5555"
     environment:
-      POSTGRES_SERVER: db
       REDIS_HOST: redis
       RABBITMQ_HOST: rabbitmq
     command: ["uv", "run", "celery", "-A", "app.celery.celery_app", "flower", "--port=5555"]


### PR DESCRIPTION
## Summary
- Removed hardcoded `POSTGRES_SERVER`: db override from prestart, `backend`, `celery_worker`, and `celery_flower` services in `docker-compose.yml`.
- Services now inherit `POSTGRES_SERVER` from .env via `env_file`, allowing the same compose file to target either the local db container or a remote host (e.g. RDS) by simply changing .env.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.
