### PR TITLE
Evaluation: rewrite Postman docs for Evaluation/STT/TTS

### DIFF
--- a/Kaapi API'S.postman_collection.json
+++ b/Kaapi API'S.postman_collection.json
@@ -1,0 +1,6551 @@
+{
+  "info": {
+    "_postman_id": "4c735746-3d39-4129-a7a4-2f67d3224687",
+    "name": "Kaapi API'S",
+    "description": "Kaapi is Project Tech4Dev’s AI platform designed to accelerate responsible AI adoption across the global development ecosystem. Acting as a middleware layer, it enables platforms like Avni, Glific, Evidential, and Dalgo to seamlessly integrate AI functionality- without each having to build or maintain their own infrastructure.\n\nKaapi will support NGOs with end-to-end AI workflows: conversation management, sector-specific co-pilots, input classification, document handling, and multi-language/multi-modal support—all guided by responsible AI practices\n\nIn the sample environment, **please add:**\n\nAPI_KEY =",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "28371440"
+  },
+  "item": [
+    {
+      "name": "Errors & Troubleshooting",
+      "description": "# Errors & Troubleshooting — Evaluation APIs\n\nAll Evaluation, STT Evaluation, and TTS Evaluation endpoints return a structured `APIResponse` envelope. On success, `success: true` and `data` carries the payload. On error, the HTTP status code reflects the error class and the body contains a `detail` (or `error`) field with a human-readable message.\n\n## HTTP status codes you may see\n\n| Status | Meaning | Common causes (Evaluation domains) | What to do |\n|---|---|---|---|\n| 400 | Bad request | Empty dataset, missing Langfuse ID, unsupported audio format, audio > 200 MB, dataset has no samples, TTS feedback on non-`SUCCESS` result, conflicting query params on Get Evaluation Run, duplicate dataset name in STT/TTS, `file_id` not found in STT dataset create | Fix the request body / query and retry |\n| 401 | Unauthorized | Missing or invalid `X-API-KEY` header | Set the `API_KEY` collection variable |\n| 403 | Forbidden | API key lacks `REQUIRE_PROJECT` permission, or the resource belongs to a different org/project | Use a key bound to the correct org+project |\n| 404 | Not found | Dataset / run / sample / result / file ID does not exist in this org/project, or `language_id` not found | Verify the ID; check it was created in this scope |\n| 409 | Conflict | Text-eval dataset name already exists in this org/project (after sanitization) | Choose a different name |\n| 413 | Payload too large | CSV upload > 1 MB (text eval) | Split the CSV or trim it; the limit is fixed |\n| 422 | Unprocessable entity | CSV missing required columns, invalid CSV MIME, empty file, sanitized name became empty, config provider not `openai`, empty `samples` list, TTS text > 5000 chars / whitespace-only, unsupported `models` value | Fix the payload per the message |\n| 500 | Internal server error | Langfuse upload failure, object-storage upload failure, batch queue failure | Retry; if persistent, ping the platform team |\n\n## High-traps to know\n\n1. **`\"models\": [\"string\"]` will 422.** The previous Postman scaffold shipped this. Use `gemini-2.5-pro` (STT) or `gemini-2.5-pro-preview-tts` (TTS).\n2. **TTS feedback on non-`SUCCESS` results returns 400.** Confirm `status` is `SUCCESS` before PATCHing.\n3. **`get_trace_info=true` on a non-completed run** doesn't error with HTTP — it returns the run with a soft message in the body (`Trace info is only available for completed evaluations. Current status: …`). Don't panic.\n4. **`resync_score=true` requires `get_trace_info=true`** (and `export_format=grouped` requires `get_trace_info=true`). Otherwise both return 400.\n5. **Dataset name sanitization is silent.** `\"My Dataset 01!\"` becomes `\"my_dataset_01\"`. Always read the name back from the API response.\n6. **Signed URLs expire after 1 hour.** Re-fetch the resource with `include_signed_url=true` if a URL has expired.\n7. **Failed runs surface the cause via `error_message`** — both at run level and per-result. Always read this field when `status == failed`.\n8. **All run processing is asynchronous via Celery + Gemini Batch API.** Poll the GET endpoint every 30–60 seconds; never tighter than 5 seconds.\n\n## Capability gaps (not supported via API today)\n\n- Cancelling an in-flight evaluation run\n- Retrying a failed run without reconstructing the request body\n- Deleting STT or TTS datasets (text-eval datasets do have DELETE)\n- Renaming a dataset\n- Appending samples to an existing dataset\n- Bulk human feedback in a single call\n- CSV/JSON results export\n- Webhook / push notification on completion — client must poll\n\n## Authentication\n\nThe collection-level auth attaches `X-API-KEY: {{API_KEY}}` to every request. Set `API_KEY` in the environment variables before sending any request. All endpoints under Evaluation/STT/TTS require this header and are scoped to the org+project that owns the key.\n",
+      "item": []
+    },
+    {
+      "name": "API Keys",
+      "item": [
+        {
+          "name": "Create API Key Route",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "multipart/form-data",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/apikeys/?project_id=1&user_id=1",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "apikeys",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "project_id",
+                  "value": "1"
+                },
+                {
+                  "key": "user_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Create a new API key for programmatic access to the platform.\n\nThe raw API key is returned **only once during creation**. Store it securely as it cannot be retrieved again. Only the key prefix will be visible in subsequent requests for security reasons."
+          },
+          "response": []
+        },
+        {
+          "name": "List API Keys Route",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "multipart/form-data",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/apikeys/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "apikeys",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "skip",
+                  "value": "0",
+                  "description": "Number of records to skip",
+                  "type": "text",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "100",
+                  "description": "Maximum records to return",
+                  "type": "text",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "List all API keys for the current project.\n\nReturns a paginated list of API keys with key prefix for security. The full key is only shown during creation and cannot be retrieved afterward."
+          },
+          "response": []
+        },
+        {
+          "name": "Verify API Key Route",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "multipart/form-data",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/apikeys/verify",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "apikeys",
+                "verify"
+              ]
+            },
+            "description": "Verify the provided API key and return the resolved auth context.\n\nThis endpoint validates the `X-API-KEY` header and returns `user_id`, `organization_id`, and `project_id` for the authenticated key."
+          },
+          "response": []
+        },
+        {
+          "name": "Delete API Keys Route",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "multipart/form-data",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/apikeys/:key_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "apikeys",
+                ":key_id"
+              ],
+              "query": [
+                {
+                  "key": "skip",
+                  "value": "0",
+                  "description": "Number of records to skip",
+                  "type": "text",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "100",
+                  "description": "Maximum records to return",
+                  "type": "text",
+                  "disabled": true
+                }
+              ],
+              "variable": [
+                {
+                  "key": "key_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Delete an API key by its ID.\n\nRevokes the API key via soft delete. Any requests using this key will fail after deletion.\n\n• Replace the `{key_id}` with the actual organization key ID in URL."
+          },
+          "response": []
+        }
+      ],
+      "description": "Manages API key generation, retrieval, and revocation for authenticating requests to the Kaapi API. Use these endpoints to create and manage programmatic access credentials."
+    },
+    {
+      "name": "Credentials",
+      "item": [
+        {
+          "name": "Read Credentials",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/credentials/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "credentials",
+                ""
+              ]
+            },
+            "description": "Get all credentials for current organization and project\n\nReturns list of all provider credentials associated with your organization and project."
+          },
+          "response": []
+        },
+        {
+          "name": "Create New Credentials",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"is_active\": true,\n    \"credential\": {\n        \"openai\": {\n            \"api_key\": \"sk-proj-...\"\n        }\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/credentials/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "credentials",
+                ""
+              ]
+            },
+            "description": "Persist new credentials for the current organization and project.\n\nCredentials are encrypted and stored securely for provider integrations (OpenAI, Langfuse, etc.). Only one credential per provider is allowed per organization-project combination. You can send credentials for a single provider or multiple providers in one request. Refer to the examples below for the required input parameters for each provider.\n\n### Supported Providers:\n\n- **LLM:** openai, sarvamai, google(gemini)\n    \n- **Observability:** langfuse\n    \n- **Audio:** elevenlabs\n    \n\n### Examples:\n\n#### Single Provider\n\n```\n{\n  \"credential\": {\n    \"openai\": {\n      \"api_key\": \"sk-proj-...\"\n    }\n  }\n}\n\n ```\n\n#### Multiple Providers\n\n```\n{\n  \"credential\": {\n    \"openai\": {\n      \"api_key\": \"sk-proj-...\"\n    },\n    \"google\": {\n      \"api_key\": \"AIzaSy...\"\n    },\n    \"sarvamai\": {\n      \"api_key\": \"sarvam-...\"\n    },\n    \"elevenlabs\": {\n      \"api_key\": \"sk_...\"\n    },\n    \"langfuse\": {\n      \"public_key\": \"pk-lf-....\",\n      \"secret_key\": \"sk-lf-...\",\n      \"host\": \"https://cloud.langfuse.com\"\n    }\n  }\n}\n\n ```"
+          },
+          "response": []
+        },
+        {
+          "name": "Delete All Credentials",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/credentials/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "credentials",
+                ""
+              ]
+            },
+            "description": "Delete all credentials for current organization and project.\n\nPermanently removes all provider credentials from the current organization and project."
+          },
+          "response": []
+        },
+        {
+          "name": "Update Credentials",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n\t\"provider\": \"openai\",\n\t\"credential\": {\n\t\t\"openai\": {\n\t\t\t\"api_key\": \"sk-proj-...\"\n\t\t}\n\t},\n\t\"is_active\": true\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/credentials/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "credentials",
+                ""
+              ]
+            },
+            "description": "Update credentials for a specific provider.\n\nUpdates existing provider credentials for the current organization and project. Provider and credential fields must be provided."
+          },
+          "response": []
+        },
+        {
+          "name": "Read Provider Credentials",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/credentials/:provider",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "credentials",
+                ":provider"
+              ],
+              "variable": [
+                {
+                  "key": "provider",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Get credentials for a specific provider.\n\nRetrieves decrypted credentials for a specific provider (e.g., `openai`, `langfuse`) for the current organization and project."
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Provider Credentials",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/credentials/:provider",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "credentials",
+                ":provider"
+              ],
+              "variable": [
+                {
+                  "key": "provider",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Delete credentials for a specific provider.\n\nPermanently removes credentials for a specific provider from the current organization and project."
+          },
+          "response": []
+        }
+      ],
+      "description": "Handles the management of third-party provider credentials (e.g., OpenAI). Includes endpoints to create, read, update, and delete credentials used to authenticate with external AI service providers."
+    },
+    {
+      "name": "Collections",
+      "item": [
+        {
+          "name": "List Collections",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/collections/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "collections",
+                ""
+              ]
+            },
+            "description": "List all _active_ collections that have been created and are not deleted.\n\n**Response Fields:**\n\n**Note:** While the API schema shows both `llm_service_id`/`llm_service_name` AND `knowledge_base_id`/`knowledge_base_provider`, each collection in the response will only include the fields relevant to what was created:\n\n- **If an Assistant was created** (with model + instructions): The response will only include `llm_service_id` and `llm_service_name` (e.g., `llm_service_name: \"gpt-4o\"` and the assistant ID)\n    \n- **If only a Vector Store was created** (without model/instructions): The response will only include `knowledge_base_id` and `knowledge_base_provider` (e.g., `knowledge_base_provider: \"openai vector store\"` and the vector store ID)"
+          },
+          "response": []
+        },
+        {
+          "name": "Create Collection",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"callback_url\": \"https://example.com/\",\n    \"provider\": \"openai\",\n    \"name\": \"\",\n    \"description\": \"\",\n    \"documents\": [\n        \"3fa85f64-5717-4562-b3fc-2c963f66afa6\"\n    ],\n    \"batch_size\": 10,\n    \"model\": \"\",\n    \"instructions\": \"\",\n    \"temperature\": 0.000001\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/collections/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "collections",
+                ""
+              ]
+            },
+            "description": "Setup and configure the document store that is pertinent to the RAG pipeline:\n\n- Create a vector store from the document IDs you received after uploading your documents through the Documents module.\n    \n- The `batch_size` parameter controls how many documents are sent to OpenAI in a single transaction when creating the vector store. This helps optimize the upload process for large document sets. If not specified, the default value is **10**.\n    \n- \\[Deprecated\\] Attach the Vector Store to an OpenAI [Assistant](https://platform.openai.com/docs/api-reference/assistants). Use parameters in the request body relevant to an Assistant to flesh out its configuration. Note that an assistant will only be created when you pass both \"model\" and \"instruction\" in the request body otherwise only a vector store will be created from the documents given.\n    \n\nIf any one of the LLM service interactions fail, all service resources are cleaned up. If an OpenAI vector Store is unable to be created, for example, all file(s) that were uploaded to OpenAI are removed from OpenAI. Failure can occur from OpenAI being down, or some parameter value being invalid. It can also fail due to document types not being accepted. This is especially true for PDFs that may not be parseable.\n\nIn the case of Openai, Vector store/assistant will be created asynchronously. The immediate response from this endpoint is `collection_job` object which is going to contain the collection \"job ID\" and status. Once the collection has been created, information about the collection will be returned to the user via the callback URL. If a callback URL is not provided, clients can check the `collection job info` endpoint with the `job_id`, to retrieve information about the creation of collection."
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Collection",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"callback_url\": \"https://example.com/\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/collections/:collection_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "collections",
+                ":collection_id"
+              ],
+              "variable": [
+                {
+                  "key": "collection_id",
+                  "value": ""
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Collection Info",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/collections/:collection_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "collections",
+                ":collection_id"
+              ],
+              "query": [
+                {
+                  "key": "include_docs",
+                  "value": "true",
+                  "disabled": true
+                },
+                {
+                  "key": "include_url",
+                  "value": "false",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "disabled": true
+                }
+              ],
+              "variable": [
+                {
+                  "key": "collection_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Retrieve detailed information about a specific collection by its collection id. This endpoint returns the collection object including its project, organization, timestamps, and service-specific details.  \n  \n\n**Response Fields:**\n\n**Note:** While the API schema shows both `llm_service_id`/`llm_service_name` AND `knowledge_base_id`/`knowledge_base_provider`, the actual response will only include the fields relevant to what was created:\n\n- **If an Assistant was created** (with model + instructions): The response will only include `llm_service_id` and `llm_service_name`\n    \n- **If only a Vector Store was created** (without model/instructions): The response will only include `knowledge_base_id` and `knowledge_base_provider`\n    \n\n**Including Documents:**\n\nIf the `include_docs` flag in the parameter is true then you will get a list of document IDs associated with a given collection as well. Note that, documents returned are not only stored by Kaapi, but also by Vector store provider.\n\nAdditionally, if you set the `include_url` parameter to true, a signed URL will be included in the response, which is a clickable link to access the retrieved document. If you don't set it to true, the URL will not be included in the response."
+          },
+          "response": []
+        },
+        {
+          "name": "Collection Job Info",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/collections/jobs/:job_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "collections",
+                "jobs",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Retrieve information about a collection job by the collection job ID. This endpoint provides detailed status and metadata for a specific collection job in Kaapi. It is especially useful for:\n\n- Fetching the collection job object, including the collection job ID, the current status, and the associated collection details.\n    \n- If the job has finished, has been successful and it was a job of creation of collection then this endpoint will fetch the associated collection details.\n    \n- If the delete-collection job succeeds, the status is set to \"successful\" and the `collection` key contains the ID of the collection that has been deleted.\n    \n\n**Response Fields for Successful Creation Jobs:**\n\n**Note:** While the API schema shows both `llm_service_id`/`llm_service_name` AND `knowledge_base_id`/`knowledge_base_provider`, the actual collection object in the response will only include the fields relevant to what was created:\n\n- **If an Assistant was created** (with model + instructions): The response will only include `llm_service_id` and `llm_service_name`\n    \n- **If only a Vector Store was created** (without model/instructions): The response will only include `knowledge_base_id` and `knowledge_base_provider`"
+          },
+          "response": []
+        }
+      ],
+      "description": "Manages data collections used within the Kaapi platform, such as datasets or grouped resources. These endpoints support creating, listing, and managing collections for use in model training or evaluation workflows."
+    },
+    {
+      "name": "Config & Version Management",
+      "item": [
+        {
+          "name": "Create Config",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"string\",\n  \"description\": \"string\",\n  \"config_blob\": {\n    \"completion\": {\n      \"provider\": \"openai-native\",\n      \"params\": {\n        \"additionalProp1\": {}\n      },\n      \"type\": \"text\"\n    },\n    \"prompt_template\": {\n      \"template\": \"string\"\n    },\n    \"input_guardrails\": [\n      {\n        \"validator_config_id\": \"3fa85f64-5717-4562-b3fc-2c963f66afa6\"\n      }\n    ],\n    \"output_guardrails\": [\n      {\n        \"validator_config_id\": \"3fa85f64-5717-4562-b3fc-2c963f66afa6\"\n      }\n    ]\n  },\n  \"commit_message\": \"string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/configs/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "configs",
+                ""
+              ]
+            },
+            "description": "Create a new LLM configuration with an initial version.\n\nConfigurations allow you to store and manage reusable LLM parameters (such as temperature, max_tokens, model selection, etc.) with version control.\n\n**Key Features:**\n\n- Automatically creates an initial version (v1) with the provided configuration\n    \n- Enforces unique configuration names per project\n    \n- Stores provider-specific parameters as flexible JSON (config_blob)\n    \n- Supports optional commit messages for tracking changes\n    \n- Kaapi providers (`openai`, `google`, `sarvamai`) — params are validated and mapped internally\n    \n- Native providers (`openai-native`, `google-native`, `sarvamai-native`) — params are passed through as-is\n    \n- Supports three completion types: `\"text\"`, `\"stt\"` and `\"tts\"`\n    \n- Supports both `input_guardrails` and `output_guardrails`\n    \n\n**Example for the config blob: OpenAI Responses API with File Search -**\n\n```\n\"config_blob\": {\n  \"completion\": {\n    \"provider\": \"openai\",\n    \"type\": \"text\",\n    \"params\": {\n      \"model\": \"gpt-4o-mini\",\n      \"instructions\": \"You are a helpful assistant for farming communities...\",\n      \"temperature\": 1,\n      \"knowledge_base_ids\": [\n        \"vs_692d71f3f5708191b1c46525f3c1e196\"\n      ]\n    }\n  }\n}\n\n ```\n\n**Example for the config blob: Google gemini STT -**\n\n```\n\"config_blob\":{\n  \"completion\": {\n    \"provider\": \"google\",\n    \"type\": \"stt\",\n    \"params\": {\n      \"model\": \"gemini-3-flash-preview\",\n      \"instructions\": \"You are a helpful assistant ...\",\n      \"input_language\": \"english\",\n      \"output_language\": \"hindi\",\n      \"temperature\": 1\n    }\n  }\n}\n\n ```\n\n**Example for the config blob: Google gemini TTS -**\n\n```\n\"config_blob\":{\n  \"completion\": {\n    \"provider\": \"google\",\n    \"type\": \"tts\",\n    \"params\": {\n      \"model\": \"gemini-2.5-pro-preview-tts\",\n      \"voice\": \"Kore\",\n      \"language\": \"hindi\",\n      \"response_format\": \"mp3\"\n    }\n  }\n}\n\n ```\n\nThe configuration name must be unique within your project. Once created, you can create additional versions to track parameter changes while maintaining the configuration history.\n\n**Provider–type support:**\n\n- `openai` / `openai-native` — `\"text\"`\n    \n- `google` / `google-native` — `\"text\"`, `\"stt\"`, `\"tts\"`\n    \n- `sarvamai` / `sarvamai-native` — `\"stt\"`, `\"tts\"`"
+          },
+          "response": []
+        },
+        {
+          "name": "List Configs",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/configs/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "configs",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "query",
+                  "value": "",
+                  "description": "Search Query",
+                  "disabled": true
+                },
+                {
+                  "key": "skip",
+                  "value": "",
+                  "description": "Number of records to skip",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "Maximum records to return",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "Query: Search string used for partial matching across configurations skip: Number of records to skip for pagination (default: 0) limit: Maximum number of records to return (default: 100, max: 100)\n\nRetrieve all configurations for the current project.\n\nReturns a paginated list of configurations ordered by most recently updated first. Each configuration includes metadata (name, description, timestamps) but excludes version details for performance."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Config",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/configs/:config_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "configs",
+                ":config_id"
+              ],
+              "variable": [
+                {
+                  "key": "config_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Retrieve a specific configuration by its ID.\n\nReturns the configuration metadata including name, description, and timestamps. This endpoint provides configuration-level details but does not include version information."
+          },
+          "response": []
+        },
+        {
+          "name": "Update Config",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"\",\n    \"description\": \"\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/configs/:config_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "configs",
+                ":config_id"
+              ],
+              "variable": [
+                {
+                  "key": "config_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Update a configuration's metadata (name or description).\n\nThis endpoint modifies only the configuration-level metadata, not the LLM parameters themselves. To change LLM parameters, create a new version instead."
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Config",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/configs/:config_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "configs",
+                ":config_id"
+              ],
+              "variable": [
+                {
+                  "key": "config_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Delete a configuration and all its versions.\n\nThis operation performs a delete, marking the configuration and all associated versions as deleted in the database while retaining records for audit purposes."
+          },
+          "response": []
+        },
+        {
+          "name": "Create Version",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"config_blob\": {\n    \"additionalProp1\": {}\n  },\n  \"commit_message\": \"string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/configs/:config_id/versions",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "configs",
+                ":config_id",
+                "versions"
+              ],
+              "variable": [
+                {
+                  "key": "config_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Create a new version for an existing configuration.\n\nTo create a new version, provide the `config_id` in the URL path and the new configuration parameters in the request body. The system will automatically create a new version under the same configuration with an incremented version number. Version numbers are automatically incremented sequentially (1, 2, 3, etc.) and cannot be manually set or skipped.\n\n## Important\n\n- This endpoint accepts partial updates using dict\\[str, Any\\] for `config_blob`.\n    \n- Only the fields that need to be updated should be provided.\n    \n- The `type` field is inherited from the existing configuration and cannot be changed. Provider and model can change between versions."
+          },
+          "response": []
+        },
+        {
+          "name": "List Versions",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/configs/:config_id/versions?config_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "configs",
+                ":config_id",
+                "versions"
+              ],
+              "query": [
+                {
+                  "key": "config_id",
+                  "value": ""
+                },
+                {
+                  "key": "skip",
+                  "value": "0",
+                  "description": "Number of records to skip",
+                  "type": "text",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "100",
+                  "description": "Maximum records to return",
+                  "type": "text",
+                  "disabled": true
+                }
+              ],
+              "variable": [
+                {
+                  "key": "config_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "List all versions for a specific configuration.\n\nReturns versions in descending order (newest first), allowing you to see the evolution of configuration parameters over time."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Versions",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/configs/:config_id/versions/:version_number",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "configs",
+                ":config_id",
+                "versions",
+                ":version_number"
+              ],
+              "variable": [
+                {
+                  "key": "config_id",
+                  "value": ""
+                },
+                {
+                  "key": "version_number",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Retrieve a specific version of a configuration.\n\nReturns the complete version details including the full configuration blob (config_blob) with all LLM parameters.  \n  \nAdd/Update the `config_id` and `version_number` in the URL."
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Version",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/configs/:config_id/versions/:version_number",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "configs",
+                ":config_id",
+                "versions",
+                ":version_number"
+              ],
+              "variable": [
+                {
+                  "key": "config_id",
+                  "value": ""
+                },
+                {
+                  "key": "version_number",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Delete a specific version of a configuration.\n\nPerforms a delete on the version, marking it as deleted while retaining the record for audit purposes.\n\nAdd/Update the `config_id` and `version_number` in the URL."
+          },
+          "response": []
+        }
+      ],
+      "description": "Manages platform and project-level configuration settings. These endpoints allow reading and updating configuration parameters that control the behavior of AI models and platform features."
+    },
+    {
+      "name": "Documents",
+      "item": [
+        {
+          "name": "List Documents",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/documents/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "documents",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "include_url",
+                  "value": "false",
+                  "description": "Include a signed URL to access each document",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "List documents uploaded to Kaapi.\n\nIf you set the `include_url` parameter to true, a signed URL will be included in the response, which is a clickable link to access the retrieved documents. If you don't set it to true, the URL will not be included in the response.\n\nFor paginated (batch-wise) data, use the skip and limit parameters.\n\n- `skip` default value: 0\n    \n- `limit` default value: 100"
+          },
+          "response": []
+        },
+        {
+          "name": "Upload Document",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "multipart/form-data",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"src\": \"\", // Required - URL of the document to be uploaded.\n    \"target_format\": \"\", // Desired output format for the uploaded document\n    \"transformer\": \"\", // Name of the transformer to apply when converting.\n    \"callback_url\": \"\" // URL to receive a callback when the document processing is complete.\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/documents/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "documents",
+                ""
+              ]
+            },
+            "description": "Upload a document to Kaapi.\n\n- If only a file is provided, the document will be uploaded and stored, and its ID will be returned.\n    \n- If a target format is specified, a transformation job will also be created to transform document into target format in the background. The response will include both the uploaded document details and information about the transformation job.\n    \n- If a callback URL is provided, you will receive a notification at that URL once the document transformation job is completed.\n    \n\n### Supported Transformations\n\nThe following (source_format → target_format) transformations are supported:\n\n- pdf → markdown\n    \n    - zerox\n        \n\n### Transformers\n\nAvailable transformer names and their implementations, default transformer is zerox:\n\n- `zerox`"
+          },
+          "response": []
+        },
+        {
+          "name": "Remove Document",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/documents/:doc_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "documents",
+                ":doc_id"
+              ],
+              "variable": [
+                {
+                  "key": "doc_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Perform a delete of the document. This makes the document invisible. It does not delete the document from cloud storage or its information from the database.\n\nIf the document is part of an active collection, those collections will be deleted using the collections delete interface. Noteably, this means all OpenAI Vector Store's and Assistant's to which this document belongs will be deleted."
+          },
+          "response": []
+        },
+        {
+          "name": "Document Info",
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          },
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"src\": \"\", // Required - URL of the document to be uploaded.\n    \"target_format\": \"\", // Desired output format for the uploaded document\n    \"transformer\": \"\", // Name of the transformer to apply when converting.\n    \"callback_url\": \"\" // URL to receive a callback when the document processing is complete.\n}"
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/documents/:doc_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "documents",
+                ":doc_id"
+              ],
+              "variable": [
+                {
+                  "key": "doc_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Retrieve all information about a given document.\n\nIf you set the `include_url` parameter to true, a signed URL will be included in the response, which is a clickable link to access the retrieved document. If you don't set it to true, the URL will not be included in the response."
+          },
+          "response": []
+        },
+        {
+          "name": "Permanent Delete Document",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"src\": \"\", // Required - URL of the document to be uploaded.\n    \"target_format\": \"\", // Desired output format for the uploaded document\n    \"transformer\": \"\", // Name of the transformer to apply when converting.\n    \"callback_url\": \"\" // URL to receive a callback when the document processing is complete.\n}"
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/documents/:doc_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "documents",
+                ":doc_id"
+              ],
+              "variable": [
+                {
+                  "key": "doc_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "This operation marks the document as deleted in the database while retaining its metadata. However, the actual file is permanently deleted from cloud storage (e.g., S3) and cannot be recovered. Only the database record remains for reference purposes.\n\nIf the document is part of an active collection, those collections will be deleted using the collections delete interface. Noteably, this means all OpenAI Vector Store's and Assistant's to which this document belongs will be deleted."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Transformation Job",
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          },
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"src\": \"\", // Required - URL of the document to be uploaded.\n    \"target_format\": \"\", // Desired output format for the uploaded document\n    \"transformer\": \"\", // Name of the transformer to apply when converting.\n    \"callback_url\": \"\" // URL to receive a callback when the document processing is complete.\n}"
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/documents/:job_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "documents",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Get the status and details of a document transformation job.\n\nIf you set the `include_url` parameter to true, a signed URL will be included in the response, which is a clickable link to access the transformed document if the job has been successful. If you don't set it to true, the URL will not be included in the response."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Multiple Transformation Job",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/documents/transformation/?job_ids=[\"3fa85f64-5717-4562-b3fc-2c963f66afa6\"]&include_url=false",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "documents",
+                "transformation",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "job_ids",
+                  "value": "[\"3fa85f64-5717-4562-b3fc-2c963f66afa6\"]",
+                  "description": "List of transformation job IDs"
+                },
+                {
+                  "key": "include_url",
+                  "value": "false",
+                  "description": "Include a signed URL for each transformed document"
+                }
+              ]
+            },
+            "description": "Get the status and details of multiple document transformation jobs by IDs.\n\nIf you set the `include_url` parameter to true, a signed URL will be included in the response, which is a clickable link to access the transformed document for successful jobs. If you don't set it to true, the URL will not be included in the response."
+          },
+          "response": []
+        }
+      ],
+      "description": "Handles document upload, retrieval, and management for use in AI workflows such as retrieval-augmented generation (RAG). Supports associating documents with projects or collections. These endpoints also support document transformation from the uploaded file format to specific target format."
+    },
+    {
+      "name": "Evaluation",
+      "item": [
+        {
+          "name": "Getting Started — Text Evaluation",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                ""
+              ]
+            },
+            "description": "# Getting Started — Text / LLM Evaluation\n\nThis walkthrough takes you from zero to a completed text-eval run using only API calls. Replace `<API_KEY>` with your `X-API-KEY` value (or set the `{{API_KEY}}` collection variable once).\n\n## Lifecycle\n\n```\n[Create config] → [Upload dataset] → [Start run] → [Poll status] → [Fetch scores]\n```\n\n## Step 1: Create or pick a config\n\nYou need a stored config whose `completion.provider == \"openai\"`. Use the **Config & Version Management** folder to create one. Note the `config_id` (UUID) and `config_version` from the response.\n\n## Step 2: Upload a dataset\n\nPrepare a CSV with exactly two columns: `question`, `answer`. Maximum **1 MB**.\n\n```bash\ncurl -X POST \\\n  -H 'X-API-KEY: <API_KEY>' \\\n  -F 'file=@qa.csv' \\\n  -F 'dataset_name=customer_support_v1' \\\n  -F 'duplication_factor=1' \\\n  https://api-staging.kaapi.ai/api/v1/evaluations/datasets\n```\n\nThe response includes `dataset_id`. Note it. The `dataset_name` may have been sanitized; use the value returned by the API for future calls.\n\n## Step 3: Start the evaluation run\n\n```bash\ncurl -X POST \\\n  -H 'X-API-KEY: <API_KEY>' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"dataset_id\": 42,\n    \"experiment_name\": \"gpt4_baseline\",\n    \"config_id\": \"f54f0d67-4817-4103-9fdf-b74b3d46733e\",\n    \"config_version\": 1\n  }' \\\n  https://api-staging.kaapi.ai/api/v1/evaluations\n```\n\nThe response returns the run ID. Note it.\n\n## Step 4: Poll for completion\n\nPoll every 30–60 seconds:\n\n```bash\ncurl -H 'X-API-KEY: <API_KEY>' \\\n  https://api-staging.kaapi.ai/api/v1/evaluations/<run_id>\n```\n\nWait until `status` is `completed`. If `status` is `failed`, read `error_message` for the cause.\n\n## Step 5: Fetch detailed scores\n\n```bash\ncurl -H 'X-API-KEY: <API_KEY>' \\\n  'https://api-staging.kaapi.ai/api/v1/evaluations/<run_id>?get_trace_info=true&export_format=row'\n```\n\nFirst call fetches from Langfuse and caches to S3. Subsequent calls return the cached data. Use `&resync_score=true` to force a re-fetch after evaluators are added.\n\n## What's not supported yet\n\n- Cancelling an in-flight run\n- Retrying a failed run (you must call POST `/evaluations` again with the same body)\n- Bulk feedback / per-trace edits via API (use Langfuse UI)\n- CSV/JSON export of results via API (use the trace data from step 5)\n- Webhook notifications on completion — client polling only\n\n## Troubleshooting\n\nSee the **Errors & Troubleshooting** item at the top of this collection.\n"
+          },
+          "response": []
+        },
+        {
+          "name": "Upload Dataset",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "multipart/form-data",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "file",
+                  "description": "CSV file with 'question' and 'answer' columns",
+                  "type": "file",
+                  "uuid": "b0a82b2a-25e4-491d-acf5-25b6da6de459",
+                  "value": null
+                },
+                {
+                  "key": "dataset_name",
+                  "value": "",
+                  "description": "Name for the dataset",
+                  "type": "text",
+                  "uuid": "0590aac6-4f31-420b-b706-ce4be9633532"
+                },
+                {
+                  "key": "description",
+                  "value": "",
+                  "description": "Optional dataset description",
+                  "type": "text",
+                  "uuid": "648326b7-a334-4cb7-b2e3-5f44743f660b"
+                },
+                {
+                  "key": "duplication_factor",
+                  "value": "",
+                  "description": "Number of times to duplicate each item (min: 1, max: 5)",
+                  "type": "text",
+                  "uuid": "d77aaa3f-23ee-456c-bb14-26c2210d0ed3"
+                }
+              ]
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/datasets",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "datasets"
+              ]
+            },
+            "description": "Upload a CSV file containing golden Q&A pairs for evaluation.\n\nDatasets allow you to store reusable question-answer pairs for systematic LLM testing with automatic validation, optional duplication for statistical significance, and Langfuse integration.\n\n**Authentication:** All Evaluation endpoints require the `X-API-KEY` header (configured at the collection level via the `{{API_KEY}}` variable). Requests are scoped to the organization and project that own the API key.\n\n**Key Features**\n- Validates CSV format and required columns (`question`, `answer`)\n- Automatic dataset-name sanitization for Langfuse compatibility (spaces/special chars → underscores, lowercased)\n- Optional item duplication for statistical significance (1–5×, default `1`)\n- Uploads to object store and syncs with Langfuse\n- Skips rows with missing values automatically\n\n**CSV Format**\n- Required columns (case-insensitive): `question`, `answer`\n- Extra columns are **not** allowed — request will be rejected with 422\n- Rows with empty `question` or `answer` are silently skipped\n\n**Limits**\n- Maximum file size: **1 MB**\n- Allowed MIME types: `text/csv`, `application/csv`, `text/plain`\n- File extension must be `.csv`\n\n**Form fields**\n- `file` (required, file): CSV file with `question` and `answer` columns\n- `dataset_name` (required, text): Will be sanitized for Langfuse (e.g. `\"My Dataset 01!\"` → `\"my_dataset_01\"`). Read the response to see the final name.\n- `description` (optional, text)\n- `duplication_factor` (optional, integer 1–5, default `1`)\n\n**Sample CSV**\n```\nquestion,answer\nWhat is your refund policy?,Refunds are processed within 7 business days.\nHow do I reset my password?,Click 'Forgot password' on the login screen.\n```\n\n**Errors specific to this endpoint**\n- `422` — CSV missing/extra columns, empty file, missing filename, invalid MIME or extension\n- `413` — File larger than 1 MB\n- `409` — Dataset name already exists in this org/project (after sanitization)\n- `500` — Langfuse upload failure (e.g. Langfuse credentials not configured)\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": []
+        },
+        {
+          "name": "List Dataset",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/datasets",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "datasets"
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "Maximum number of datasets to return",
+                  "disabled": true
+                },
+                {
+                  "key": "offset",
+                  "value": "",
+                  "description": "Number of datasets to skip",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "List all evaluation datasets for the current organization and project.\n\nReturns a paginated list ordered by most recent first. Each entry includes the dataset ID, sanitized name, item counts (original and after duplication), duplication factor, Langfuse dataset ID, and object store URL.\n\n**Query parameters**\n- `limit` (optional, integer, 1–100, default `50`)\n- `offset` (optional, integer, ≥0, default `0`)\n\n**Response shape**\n```json\n{\n  \"success\": true,\n  \"data\": [\n    {\n      \"dataset_id\": 42,\n      \"dataset_name\": \"customer_support_v1\",\n      \"description\": \"100 FAQs from customer support tickets\",\n      \"total_items\": 300,\n      \"original_items\": 100,\n      \"duplication_factor\": 3,\n      \"langfuse_dataset_id\": \"clxxxxxxxxx\",\n      \"object_store_url\": \"s3://...\"\n    }\n  ]\n}\n```\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Dataset",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/datasets/:dataset_id?include_signed_url=false",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "datasets",
+                ":dataset_id"
+              ],
+              "query": [
+                {
+                  "key": "include_signed_url",
+                  "value": "false",
+                  "description": "Include signed URL for dataset",
+                  "disabled": true
+                }
+              ],
+              "variable": [
+                {
+                  "key": "dataset_id",
+                  "value": "",
+                  "description": "Database ID of the dataset"
+                }
+              ]
+            },
+            "description": "Get details of a specific dataset by its database ID.\n\nReturns dataset metadata, Langfuse integration details, and the object store URL for the CSV file.\n\n**Path parameter**\n- `dataset_id` (integer, required) — database ID returned by Upload Dataset\n\n**Query parameter**\n- `include_signed_url` (optional, boolean, default `false`) — when `true`, the response includes a time-limited signed URL for downloading the CSV directly from object storage. Signed URLs expire after **1 hour**.\n\n**Errors**\n- `404` — Dataset not found in this org/project\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Dataset",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/datasets/:dataset_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "datasets",
+                ":dataset_id"
+              ],
+              "variable": [
+                {
+                  "key": "dataset_id",
+                  "value": "",
+                  "description": "Database ID of the dataset"
+                }
+              ],
+              "query": []
+            },
+            "description": "Delete a dataset by its database ID.\n\nRemoves the dataset record from the database. The underlying CSV in object storage is retained for audit purposes but the dataset will no longer be available for new evaluation runs.\n\n**Cascade behaviour**\n- Past evaluation runs that referenced this dataset remain readable — their `dataset_id` becomes a dangling reference but their results, scores, and metadata are preserved.\n- The Langfuse dataset is **not** automatically deleted from Langfuse.\n\n**Path parameter**\n- `dataset_id` (integer, required)\n\n**Errors**\n- `404` — Dataset not found in this org/project\n- `400` — Deletion failed (rare; database integrity issue)\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": []
+        },
+        {
+          "name": "Evaluate",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"dataset_id\": 0,\n    \"experiment_name\": \"\",\n    \"config_id\": \"3fa85f64-5717-4562-b3fc-2c963f66afa6\",\n    \"config_version\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations"
+              ]
+            },
+            "description": "Start an evaluation run using the OpenAI Batch API.\n\nEvaluations systematically test an LLM configuration against a predefined dataset. Processing is asynchronous via the OpenAI Batch API; use `GET /evaluations/{evaluation_id}` to monitor progress and retrieve results.\n\n**Authentication:** All Evaluation endpoints require the `X-API-KEY` header (configured at the collection level via the `{{API_KEY}}` variable). Requests are scoped to the organization and project that own the API key.\n\n**Prerequisites**\n1. Upload a dataset via `POST /evaluations/datasets` and note the `dataset_id`.\n2. Create a config via `POST /configs` and note its `config_id` (UUID) and `config_version`. The config's `completion.provider` **must be `openai`** — other providers are rejected with `422`.\n3. Ensure Langfuse credentials are configured for the project (the dataset needs a Langfuse dataset ID).\n\n**Request body**\n```json\n{\n  \"dataset_id\": 123,\n  \"experiment_name\": \"gpt4_file_search_v1\",\n  \"config_id\": \"f54f0d67-4817-4103-9fdf-b74b3d46733e\",\n  \"config_version\": 1\n}\n```\n\n**Field details**\n- `dataset_id` (integer, required)\n- `experiment_name` (string, required) — friendly name shown alongside runs in Langfuse\n- `config_id` (UUID, required)\n- `config_version` (integer, required, ≥1)\n\n**What happens next**\n1. The dataset's items are fetched from Langfuse.\n2. A batch processing job is created via the OpenAI Batch API.\n3. Status is updated to `processing`; a background worker polls every 60 s.\n4. On completion, scores are computed and stored. Poll the **Get Evaluation Run Status** endpoint to retrieve them.\n\n**Errors specific to this endpoint**\n- `404` — Dataset not found in this org/project\n- `400` — Dataset has no Langfuse ID (Langfuse credentials were missing when the dataset was created); config cannot be resolved\n- `422` — Config provider is not `openai`\n- `500` — Failed to enqueue the batch job\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": []
+        },
+        {
+          "name": "List Evaluation Runs",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations"
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "50",
+                  "disabled": true
+                },
+                {
+                  "key": "offset",
+                  "value": "0",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "List all evaluation runs for the current organization and project.\n\nReturns a paginated list ordered by most recent first. Each run includes ID, name, dataset reference, config reference, status, total items, batch job IDs, scores (when available), cost, and timestamps.\n\n**Query parameters**\n- `limit` (optional, integer, default `50`)\n- `offset` (optional, integer, default `0`)\n\n**Status enum**\n- `pending` — run record created, batch not yet submitted\n- `processing` — batch is running on OpenAI\n- `completed` — results ready; query the run for scores\n- `failed` — read the `error_message` field on the run for the cause\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Evaluation Run Status",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/:evaluation_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                ":evaluation_id"
+              ],
+              "query": [
+                {
+                  "key": "get_trace_info",
+                  "value": "false",
+                  "description": "If true, fetch and include Langfuse trace scores with Q&A context. On first request, data is fetched from Langfuse and cached. Subsequent requests return cached data.",
+                  "disabled": true
+                },
+                {
+                  "key": "resync_score",
+                  "value": "false",
+                  "description": "If true, clear cached scores and re-fetch from Langfuse. Useful when new evaluators have been added or scores have been updated. Requires get_trace_info=true.",
+                  "type": "text",
+                  "disabled": true
+                },
+                {
+                  "key": "export_format",
+                  "value": "row",
+                  "description": "Controls the Traces structure.'grouped' collates repeated questions horizontally using Parent Question ID.",
+                  "type": "text",
+                  "disabled": true
+                }
+              ],
+              "variable": [
+                {
+                  "key": "evaluation_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Get the current status and results of a specific evaluation run.\n\nReturns evaluation metadata, processing status, configuration references, progress metrics, and (optionally) Langfuse trace scores with full Q&A context. Use this endpoint to poll an in-flight run and to fetch final scores.\n\n**Polling guidance:** Evaluation runs are processed asynchronously by a background worker. Poll this endpoint every 30–60 seconds until `status` is `completed` or `failed`. Do not poll faster than once per 5 seconds.\n\n**Status lifecycle:** `pending` → `processing` → `completed` | `failed`.\n\n**Path parameter**\n- `evaluation_id` (integer, required) — ID returned by the start endpoint\n\n**Query parameters**\n- `get_trace_info` (optional, default `false`) — include Langfuse trace scores with Q&A context. **Only available when `status == completed`**; calling it on an in-flight run returns the run with a soft error in the response body (`Trace info is only available for completed evaluations. Current status: …`).\n- `resync_score` (optional, default `false`) — clear cached scores and re-fetch from Langfuse. Useful when evaluators have been added or updated since the last call. **Requires `get_trace_info=true`** (otherwise returns `400`).\n- `export_format` (optional, default `row`, allowed: `row`, `grouped`) — controls the structure of `traces`. `grouped` collates repeated questions horizontally using parent question ID. **`grouped` requires `get_trace_info=true`** (otherwise returns `400`).\n\n**Reading a failed run**\nWhen `status == failed`, read the top-level `error_message` field on the run for the cause. Common reasons: OpenAI batch quota exceeded, dataset became unavailable in Langfuse, embedding job failure.\n\n**Score Format** (`get_trace_info=true`, `export_format=row`)\n```json\n{\n  \"summary_scores\": [\n    {\n      \"name\": \"cosine_similarity\",\n      \"avg\": 0.87,\n      \"std\": 0.12,\n      \"total_pairs\": 50,\n      \"data_type\": \"NUMERIC\"\n    },\n    {\n      \"name\": \"response_category\",\n      \"distribution\": {\"CORRECT\": 10, \"PARTIAL\": 5, \"INCORRECT\": 2},\n      \"total_pairs\": 17,\n      \"data_type\": \"CATEGORICAL\"\n    }\n  ],\n  \"traces\": [\n    {\n      \"trace_id\": \"uuid-123\",\n      \"question\": \"What is 2+2?\",\n      \"llm_answer\": \"4\",\n      \"ground_truth_answer\": \"4\",\n      \"scores\": [\n        {\"name\": \"cosine_similarity\", \"value\": 0.95, \"data_type\": \"NUMERIC\"},\n        {\"name\": \"correctness\", \"value\": 1, \"data_type\": \"NUMERIC\", \"comment\": \"Response is correct\"}\n      ]\n    }\n  ]\n}\n```\n\n**Score Format** (`get_trace_info=true`, `export_format=grouped`)\nSame shape as above but `traces` becomes:\n```json\n[\n  {\n    \"question_id\": 1,\n    \"question\": \"What is Python?\",\n    \"ground_truth_answer\": \"Python is a high-level programming language.\",\n    \"llm_answers\": [\"Answer from run 1...\", \"Answer from run 2...\"],\n    \"trace_ids\": [\"uuid-123\", \"uuid-456\"],\n    \"scores\": [\n      [{\"name\": \"cosine_similarity\", \"value\": 0.82, \"data_type\": \"NUMERIC\"}],\n      [{\"name\": \"cosine_similarity\", \"value\": 0.75, \"data_type\": \"NUMERIC\"}]\n    ]\n  }\n]\n```\n\n**Score details**\n- NUMERIC scores include `avg` and `std` in summary; values rounded to 2 dp\n- CATEGORICAL scores include distribution counts in summary\n- Only complete scores are included (all traces have been rated)\n- First fetch from Langfuse is cached to S3; subsequent reads serve from cache for speed. Use `resync_score=true` to bypass the cache.\n\n**Errors specific to this endpoint**\n- `404` — Run not found or not accessible to this org/project\n- `400` — `resync_score=true` without `get_trace_info=true`\n- `400` — `export_format=grouped` without `get_trace_info=true`\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": []
+        }
+      ],
+      "description": "Contains general-purpose evaluation endpoints for assessing AI model outputs across different tasks. Use these to submit evaluation jobs and retrieve scored results."
+    },
+    {
+      "name": "Fine Tuning",
+      "item": [
+        {
+          "name": "Fine Tune From CSV",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "multipart/form-data",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "file",
+                  "description": "CSV file to use for fine-tuning",
+                  "type": "file",
+                  "uuid": "99c40899-407a-4e96-9e9b-9004447b50b2",
+                  "value": null
+                },
+                {
+                  "key": "base_model",
+                  "value": "",
+                  "type": "text",
+                  "uuid": "6392928e-d892-4e5e-8029-2a047abd5902"
+                },
+                {
+                  "key": "split_ratio",
+                  "value": "",
+                  "type": "text",
+                  "uuid": "b11c4185-0d53-4bde-aa86-be89bb383154"
+                },
+                {
+                  "key": "system_prompt",
+                  "value": "",
+                  "type": "text",
+                  "uuid": "d3c1c541-5405-4fb2-a793-f1e88a7ab0bb"
+                }
+              ]
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/fine_tuning/fine_tune",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "fine_tuning",
+                "fine_tune"
+              ]
+            },
+            "description": "Initiate fine-tuning of an OpenAI model using a CSV dataset. The CSV must include:\n\n- A column named `query`, `question`, or `message` containing user inputs or messages.\n    \n- A column named `label` indicating whether a given message is a genuine query or not (e.g., casual conversation or small talk).\n    \n\nThe `split_ratio` form field is a comma-separated string that determines how your data is divided between training and testing. For example, `\"0.5\"` means 50% training and 50% testing. You can provide multiple ratios—for instance, `\"0.7,0.9\"`. This will trigger multiple fine-tuning jobs, one for each ratio. You would also need to specify a `base_model` that you want to fine-tune.\n\nThe `system_prompt` form field allows you to define an initial instruction or context-setting message that will be included in the training data. This message helps the model learn how it is expected to behave when responding to user inputs. It is prepended as the first message in each training example during fine-tuning.\n\nThe system handles the fine-tuning process by interacting with OpenAI's APIs under the hood. These include:\n\n- [Openai File create to upload your training and testing files](https://platform.openai.com/docs/api-reference/files/create)\n    \n- [Openai Fine Tuning Job create to initiate each fine-tuning job](https://platform.openai.com/docs/api-reference/fine_tuning/create)\n    \n\nIf successful, the response will include a message along with a list of fine-tuning jobs that were initiated. Each job object includes:\n\n```\n{\n    \"id\": \"the internal ID of the fine-tuning job\",\n    \"document_id\": \"the ID of the document used for fine-tuning\",\n    \"split_ratio\": \"the data split used for that job\",\n    \"status\": \"the initial status of the job (usually 'pending')\"\n}\n\n ```"
+          },
+          "response": []
+        },
+        {
+          "name": "Refresh Fine Tune Status",
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          },
+          "request": {
+            "method": "GET",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "file",
+                  "description": "CSV file to use for fine-tuning",
+                  "type": "file",
+                  "uuid": "99c40899-407a-4e96-9e9b-9004447b50b2",
+                  "value": null
+                },
+                {
+                  "key": "base_model",
+                  "value": "",
+                  "type": "text",
+                  "uuid": "6392928e-d892-4e5e-8029-2a047abd5902"
+                },
+                {
+                  "key": "split_ratio",
+                  "value": "",
+                  "type": "text",
+                  "uuid": "b11c4185-0d53-4bde-aa86-be89bb383154"
+                },
+                {
+                  "key": "system_prompt",
+                  "value": "",
+                  "type": "text",
+                  "uuid": "d3c1c541-5405-4fb2-a793-f1e88a7ab0bb"
+                }
+              ]
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/fine_tuning/:fine_tuning_id/refresh",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "fine_tuning",
+                ":fine_tuning_id",
+                "refresh"
+              ],
+              "variable": [
+                {
+                  "key": "fine_tuning_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Refreshes the status of a fine-tuning job by retrieving the latest information from OpenAI. If there are any changes in status, fine-tuned model, or error message, the local job record is updated accordingly. Returns the latest state of the job.\n\nWhen a job is completed and updated in the database, model evaluation for that fine-tuned model will start automatically.\n\nOpenAI's job status is retrieved using their [Fine-tuning Job Retrieve API](https://platform.openai.com/docs/api-reference/fine_tuning/retrieve).\n\n• Replace the `fine_tuning_id` with actual fine tuning ID in URL."
+          },
+          "response": []
+        },
+        {
+          "name": "Retrieve Jobs By Document",
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          },
+          "request": {
+            "method": "GET",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "file",
+                  "description": "CSV file to use for fine-tuning",
+                  "type": "file",
+                  "uuid": "99c40899-407a-4e96-9e9b-9004447b50b2",
+                  "value": null
+                },
+                {
+                  "key": "base_model",
+                  "value": "",
+                  "type": "text",
+                  "uuid": "6392928e-d892-4e5e-8029-2a047abd5902"
+                },
+                {
+                  "key": "split_ratio",
+                  "value": "",
+                  "type": "text",
+                  "uuid": "b11c4185-0d53-4bde-aa86-be89bb383154"
+                },
+                {
+                  "key": "system_prompt",
+                  "value": "",
+                  "type": "text",
+                  "uuid": "d3c1c541-5405-4fb2-a793-f1e88a7ab0bb"
+                }
+              ]
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/fine_tuning/:document_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "fine_tuning",
+                ":document_id"
+              ],
+              "variable": [
+                {
+                  "key": "document_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Retrieves all fine-tuning jobs associated with the given document ID for the current project\n\n• Replace the `document_id` with actual Document ID in URL."
+          },
+          "response": []
+        }
+      ],
+      "description": "Contains endpoints for managing fine-tuning jobs on language models. Use these to submit training data, monitor fine-tuning progress, and manage custom model versions."
+    },
+    {
+      "name": "LLM",
+      "item": [
+        {
+          "name": "LLM Call",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"query\": {\n        \"input\": \"string\",\n        \"conversation\": {\n            \"id\": \"string\",\n            \"auto_create\": false\n        }\n    },\n    \"config\": {\n        \"id\": \"3fa85f64-5717-4562-b3fc-2c963f66afa6\",\n        \"version\": 1,\n        \"blob\": {\n            \"completion\": {\n                \"provider\": \"openai-native\",\n                \"params\": {\n                    \"additionalProp1\": {}\n                },\n                \"type\": \"text\"\n            },\n            \"prompt_template\": {\n                \"template\": \"string\"\n            },\n            \"input_guardrails\": [\n                {\n                    \"validator_config_id\": \"3fa85f64-5717-4562-b3fc-2c963f66afa6\"\n                }\n            ],\n            \"output_guardrails\": [\n                {\n                    \"validator_config_id\": \"3fa85f64-5717-4562-b3fc-2c963f66afa6\"\n                }\n            ]\n        }\n    },\n    \"callback_url\": \"https://example.com/\",\n    \"include_provider_raw_response\": false,\n    \"request_metadata\": {\n        \"additionalProp1\": {}\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/llm/call",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "llm",
+                "call"
+              ]
+            },
+            "description": "Make an LLM API call using either a stored configuration or an ad-hoc configuration.\n\nThis endpoint initiates an asynchronous LLM call job. The request is queued for processing, and results are delivered via the callback URL when complete.\n\n### Key Parameters\n\n**`query`** (required) - Query parameters for this LLM call:\n\n- **`input`** (required) — User input in one of three forms:\n    \n    1. \"input\": \"Hello\"\n        \n    2. \"input\": {\"type\": \"text\", \"content\": {\"format\": \"text\", \"value\": \"Hello\"}}\n        \n    \n    - **List of structured inputs** — for multimodal use cases (supports `image`, `pdf`, and `text`; `audio` is only supported as a single structured input)\n        \n    \n    **Supported input types:** `text`, `audio`, `image`, `pdf`\n    \n    **Content format by type:**\n    \n    - `text` — format: `\"text\"`\n        \n    - `audio` — format: `\"base64\"`, optional `mime_type` (e.g. `audio/wav`)\n        \n    - `image` — format: `\"base64\"` or `\"url\"`, optional `mime_type` (default: `image/png`)\n        \n    - `pdf` — format: `\"base64\"` or `\"url\"`, optional `mime_type` (default: `application/pdf`)\n        \n    \n    For `image` and `pdf`, `content` can be a single object or a list of objects.\n    \n- **`conversation`** (optional) — Conversation configuration\n    \n    - `id` (string): Existing conversation ID to continue\n        \n    - `auto_create` (boolean, default false): Create a new conversation if no ID provided\n        \n    - **Note**: Cannot specify both `id` and `auto_create=true`\n        \n\n**`config`** (required) - Configuration for the LLM call (just choose one mode):\n\n- **Mode 1: Stored Configuration**\n    \n    - `id` (UUID): Configuration ID\n        \n    - `version` (integer >= 1): Version number\n        \n    - **Both required together**\n        \n    - **Note**: When using stored configuration, do not include the `blob` field in the request body\n        \n- **Mode 2: Ad-hoc Configuration**\n    \n    - `blob` (object): Complete configuration object\n        \n        - `completion` (required, object): Completion configuration\n            \n            - `provider` (required, string): Provider type — `\"openai\"` or `\"google\"` (Kaapi abstraction), or `\"openai-native\"` or `\"google-native\"` (pass-through)\n                \n            - `type` (required, string): Completion type — `\"text\"`, `\"stt\"`, `\"tts\"`\n                \n            - `params` (required, object): Parameters structure depends on provider and type (see schema for detailed structure)\n                \n        - `input_guardrails` (optional, list)\n            \n        - `output_guardrails` (optional, list)\n            \n    - **Note**\n        \n        - When using ad-hoc configuration, do not include `id` and `version` fields\n            \n        - When using the Kaapi abstraction, parameters that are not supported by the selected provider or model are automatically suppressed. If any parameters are ignored, a list of warnings is included in the metadata.warnings. For example, the GPT-5 model does not support the temperature parameter, so Kaapi will neither throw an error nor pass this parameter to the model; instead, it will return a warning in the metadata.warnings response.\n            \n    - **Recommendation**: Use stored configs (Mode 1) for production; use ad-hoc configs only for testing/validation\n        \n    - **Schema**: Check the API schema or examples below for the complete parameter structure for each provider type\n        \n\n**`callback_url`** (optional, HTTPS URL):\n\n- Webhook endpoint to receive the response\n    \n- Must be a valid HTTPS URL\n    \n- If not provided, response is only accessible through job status\n    \n\n**`include_provider_raw_response`** (optional, boolean, default false):\n\n- When true, includes the unmodified raw response from the LLM provider\n    \n\n**`request_metadata`** (optional, object):\n\n- Custom JSON metadata\n    \n- Passed through unchanged in the response\n    \n\n### Note\n\n- `warnings` list is automatically added in response metadata when using Kaapi configs if any parameters are suppressed or adjusted (e.g., temperature on reasoning models)"
+          },
+          "response": []
+        },
+        {
+          "name": "Get LLM Call Status",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/llm/call/:job_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "llm",
+                "call",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Retrieve the status and results of an LLM call job by job ID.\n\nThis endpoint allows you to poll for the status and results of an asynchronous LLM call job that was previously initiated via the POST `/llm/call` endpoint.\n\n### Notes\n\n- Add/Update the `job_id` in the URL.\n    \n- This endpoint returns both the job status AND the actual LLM response when complete\n    \n- LLM responses are also delivered asynchronously via the callback URL (if provided)\n    \n- Jobs can be queried at any time after creation"
+          },
+          "response": []
+        },
+        {
+          "name": "LLM Chain",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"query\": {\n        \"input\": \"string\",\n        \"conversation\": {\n            \"id\": \"string\",\n            \"auto_create\": false\n        }\n    },\n    \"blocks\": [\n        {\n            \"config\": {\n                \"id\": \"3fa85f64-5717-4562-b3fc-2c963f66afa6\",\n                \"version\": 1,\n                \"blob\": {\n                    \"completion\": {\n                        \"provider\": \"openai-native\",\n                        \"params\": {\n                            \"additionalProp1\": {}\n                        },\n                        \"type\": \"text\"\n                    },\n                    \"prompt_template\": {\n                        \"template\": \"string\"\n                    },\n                    \"input_guardrails\": [\n                        {\n                            \"validator_config_id\": \"3fa85f64-5717-4562-b3fc-2c963f66afa6\"\n                        }\n                    ],\n                    \"output_guardrails\": [\n                        {\n                            \"validator_config_id\": \"3fa85f64-5717-4562-b3fc-2c963f66afa6\"\n                        }\n                    ]\n                }\n            },\n            \"include_provider_raw_response\": false,\n            \"intermediate_callback\": false\n        }\n    ],\n    \"callback_url\": \"https://example.com/\",\n    \"request_metadata\": {\n        \"additionalProp1\": {}\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/llm/chain",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "llm",
+                "chain"
+              ]
+            },
+            "description": "Execute a chain of LLM calls sequentially, where each block's output becomes the next block's input.\n\nThis endpoint initiates an asynchronous LLM chain job. The request is queued for processing, and results are delivered via the callback URL when complete.\n\n### Key Parameters\n\n**`query`** (required) - Initial query input for the first block in the chain:\n\n- `input` (required): User question/prompt/query — accepts a plain string, a structured input object (`text`, `audio`, `image`, `pdf`), or a list of structured inputs\n    \n- `conversation` (optional, object): Conversation configuration\n    \n    - `id` (optional, string): Existing conversation ID to continue\n        \n    - `auto_create` (optional, boolean, default false): Create new conversation if no ID provided\n        \n    - **Note**: Cannot specify both `id` and `auto_create=true`\n        \n\n**`blocks`** (required, array, min 1 block) - Ordered list of blocks to execute sequentially. Each block contains:\n\n- `config` (required) - Configuration for this block's LLM call (just choose one mode):\n    \n    - **Mode 1: Stored Configuration**\n        \n        - `id` (UUID): Configuration ID\n            \n        - `version` (integer >= 1): Version number\n            \n        - **Both required together**\n            \n        - **Note**: When using stored configuration, do not include the `blob` field in the request body\n            \n    - **Mode 2: Ad-hoc Configuration**\n        \n        - `blob` (object): Complete configuration object\n            \n            - `completion` (required, object): Completion configuration\n                \n                - `provider` (required, string): Kaapi providers (`openai`, `google`, `sarvamai`) — params are validated and mapped internally. Native providers (`openai-native`, `google-native`, `sarvamai-native`) — params are passed through as-is\n                    \n                - `type` (required, string): Completion type — `\"text\"`, `\"stt\"`, or `\"tts\"`\n                    \n                - `params` (required, object): Parameters structure depends on provider and type (see schema for detailed structure)\n                    \n            - `input_guardrails` (optional, array): Guardrails applied to validate/sanitize input before the LLM call\n                \n            - `output_guardrails` (optional, array): Guardrails applied to validate/sanitize output after the LLM call\n                \n            - `prompt_template` (optional, object): Template for text interpolation\n                \n                - `template` (required, string): Template string with `{{input}}` placeholder — replaced with the block's input before execution\n                    \n        - **Note**\n            \n            - When using ad-hoc configuration, do not include `id` and `version` fields\n                \n            - When using the Kaapi abstraction, parameters that are not supported by the selected provider or model are automatically suppressed. If any parameters are ignored, a list of warnings is included in the metadata.warnings.\n                \n        - **Recommendation**: Use stored configs (Mode 1) for production; use ad-hoc configs only for testing/validation\n            \n        - **Schema**: Check the API schema or examples below for the complete parameter structure for each provider type\n            \n- `include_provider_raw_response` (optional, boolean, default false):\n    \n    - When true, includes the unmodified raw response from the LLM provider for this block\n        \n- `intermediate_callback` (optional, boolean, default false):\n    \n    - When true, sends an intermediate callback after this block completes with the block's response, usage, and position in the chain\n        \n\n**`callback_url`** (optional, HTTPS URL):\n\n- Webhook endpoint to receive the final response and intermediate callbacks\n    \n- Must be a valid HTTPS URL\n    \n- If not provided, response is only accessible through job status\n    \n\n**`request_metadata`** (optional, object):\n\n- Custom JSON metadata\n    \n- Passed through unchanged in the response\n    \n\n### Note\n\n- If any block fails, the chain stops immediately — no subsequent blocks are executed\n    \n- `warnings` list is automatically added in response metadata when using Kaapi configs if any parameters are suppressed or adjusted (e.g., temperature on reasoning models)"
+          },
+          "response": []
+        }
+      ],
+      "description": "Provides core endpoints for interacting with large language models (LLMs) on the Kaapi platform. Includes prompt submission, response retrieval, and model configuration for various LLM providers.\n\nLarge Language Model inference and interaction endpoints."
+    },
+    {
+      "name": "Languages",
+      "item": [
+        {
+          "name": "List Languages",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/languages/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "languages",
+                ""
+              ]
+            },
+            "description": "Retrieve a list of all active languages supported by the platform.\n\nReturns language details including label, locale code, and native script representation.\n\nFor paginated (batch-wise) data, use the skip and limit parameters.\n\n- `skip` default value: 0\n    \n- `limit` default value: 100"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Language By ID",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/languages/:language_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "languages",
+                ":language_id"
+              ],
+              "variable": [
+                {
+                  "key": "language_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Retrieve a specific language by its ID.\n\nReturns language details including label, locale code, and native script representation."
+          },
+          "response": []
+        }
+      ],
+      "description": "Provides endpoints to retrieve and manage the list of supported languages on the Kaapi platform, used for configuring multilingual AI model behavior and evaluation settings."
+    },
+    {
+      "name": "Model Evaluation",
+      "item": [
+        {
+          "name": "Evaluate Models",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"fine_tuning_ids\": [\n        0\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/model_evaluation/evaluate_models/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "model_evaluation",
+                "evaluate_models",
+                ""
+              ]
+            },
+            "description": "Start evaluations for one or more fine-tuned models.\n\nFor each fine-tuning job ID provided, this endpoint fetches the fine-tuned model and test data, then queues a background task that runs predictions on the test set and computes evaluation scores (Matthews correlation coefficient). Returns created or active evaluation records."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Top Model By Doc ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/model_evaluation/:document_id/top_model",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "model_evaluation",
+                ":document_id",
+                "top_model"
+              ],
+              "variable": [
+                {
+                  "key": "document_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Get the top-performing model for a specific document.\n\nReturns the best model trained on the given document, ranked by Matthews correlation coefficient (MCC) across all evaluations. Includes prediction data file URL if available.\n\n• Replace `document_id` with acutal Uploaded Document ID in URL."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Evaluation By Doc ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/model_evaluation/:document_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "model_evaluation",
+                ":document_id"
+              ],
+              "variable": [
+                {
+                  "key": "document_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Get all model evaluations for a specific document.\n\nReturns list of all evaluation records for models trained on the given document within the current project, including prediction data file URLs.\n\n• Replace `document_id` with acutal Uploaded Document ID in URL."
+          },
+          "response": []
+        }
+      ],
+      "description": "Provides endpoints to run and manage evaluations across AI models. Use these to benchmark model performance, compare outputs, and track evaluation results."
+    },
+    {
+      "name": "Onboarding",
+      "item": [
+        {
+          "name": "Onboard",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"organization_name\": \"\",\n    \"project_name\": \"\",\n    \"email\": \"\",\n    \"password\": \"\",\n    \"user_name\": \"\",\n    \"credentials\": [\n        {\n            \"openai\": {\n                \"api_key\": \"...\"\n            }\n        },\n        {\n            \"google\": {\n                \"api_key\": \"...\"\n            }\n        }\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/onboard",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "onboard"
+              ]
+            },
+            "description": "Creates an organization, project, and user in a single transaction.\n\n**Note:** credentials (optional): List of API provider credentials.\n\nIf not provided, default configuration will be used."
+          },
+          "response": [
+            {
+              "name": "Response",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"organization_name\": \"Test\",\n    \"project_name\": \"Test\",\n    \"email\": \"test@gmail.com\",\n    \"password\": \"Test8954@\",\n    \"user_name\": \"Test\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "http://localhost:8000/api/v1/onboard",
+                  "protocol": "http",
+                  "host": [
+                    "localhost"
+                  ],
+                  "port": "8000",
+                  "path": [
+                    "api",
+                    "v1",
+                    "onboard"
+                  ]
+                }
+              },
+              "status": "Created",
+              "code": 201,
+              "_postman_previewlanguage": "Text",
+              "header": [
+                {
+                  "key": "date",
+                  "value": "Mon, 13 Apr 2026 16:01:58 GMT"
+                },
+                {
+                  "key": "server",
+                  "value": "uvicorn"
+                },
+                {
+                  "key": "content-length",
+                  "value": "285"
+                },
+                {
+                  "key": "content-type",
+                  "value": "application/json"
+                },
+                {
+                  "key": "x-request-id",
+                  "value": "ca6788aa25f74cefa7a5ded2b29d7f0c"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n    \"success\": true,\n    \"data\": {\n        \"organization_id\": 151,\n        \"organization_name\": \"Test\",\n        \"project_id\": 167,\n        \"project_name\": \"Test\",\n        \"user_id\": 200,\n        \"user_email\": \"test@gmail.com\",\n        \"api_key\": \"ApiKey f3iGRmUJSyiB4FOjgRxznw2Rbja1uXsS8HF58LDzyfzTUc5by3ctw6f6-r2RfGRh4\"\n    },\n    \"error\": null,\n    \"errors\": null,\n    \"metadata\": null\n}"
+            }
+          ]
+        }
+      ],
+      "description": "Contains the onboarding endpoint used to register and initialize a new user or organization on the Kaapi platform. This is typically the first step before accessing other API resources."
+    },
+    {
+      "name": "Organizations",
+      "item": [
+        {
+          "name": "Read Organizations",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/organizations/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "organizations",
+                ""
+              ]
+            },
+            "description": "Retrieves a list of all organizations associated with the authenticated user. Returns organization details such as name and active status."
+          },
+          "response": []
+        },
+        {
+          "name": "Create New Organization",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"\",\n    \"is_active\": true\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/organizations/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "organizations",
+                ""
+              ]
+            },
+            "description": "Creates a new organization on the Kaapi platform. Accepts a JSON body with the following fields:\n- `name` (string): The name of the organization.\n- `is_active` (boolean): Whether the organization is active."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Organization By ID",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/organizations/:org_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "organizations",
+                ":org_id"
+              ],
+              "variable": [
+                {
+                  "key": "org_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Retrieves the details of a specific organization by its ID. Accepts the following query parameter:  \n• `org_id` (integer): The unique ID of the organization to retrieve."
+          },
+          "response": []
+        },
+        {
+          "name": "Update Organizations",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/organizations/:org_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "organizations",
+                ":org_id"
+              ],
+              "variable": [
+                {
+                  "key": "org_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Updates the details of an existing organization. Accepts the following query parameter:\n- `org_id` (integer): The unique ID of the organization to update.\n\nSupports partial updates to organization fields such as name and active status."
+          },
+          "response": []
+        }
+      ],
+      "description": "Contains endpoints for managing organizations within the Kaapi platform. Supports creating, reading, updating, and deleting organization records that serve as the top-level grouping for users and projects."
+    },
+    {
+      "name": "OpenAI LLM Response",
+      "item": [
+        {
+          "name": "OpenAI Response",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"assistant_id\": \"\",\n    \"question\": \"\",\n    \"callback_url\": \"\",\n    \"response_id\": \"\",\n    \"additionalProp1\": {}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/responses",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "responses"
+              ]
+            },
+            "description": "Create an asynchronous OpenAI Responses API call.\n\nProcesses requests with background execution. Returns job status immediately and delivers results via callback given in the request body when completed."
+          },
+          "response": []
+        },
+        {
+          "name": "OpenAI Response Sync",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"model\": \"\",\n    \"instructions\": \"\",\n    \"vector_store_ids\": [\n        \"\"\n    ],\n    \"max_num_results\": 20,\n    \"temperature\": 0.1,\n    \"response_id\": \"\",\n    \"question\": \"\",\n    \"additionalProp1\": {}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/responses/sync",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "responses",
+                "sync"
+              ]
+            },
+            "description": "Create a synchronous OpenAI Responses API call.\n\nSynchronous endpoint for immediate responses with Langfuse tracing integration. Useful for benchmarking and testing."
+          },
+          "response": []
+        }
+      ],
+      "description": "Contains endpoints for sending prompts to OpenAI large language models and retrieving their responses. Used for testing and integrating LLM-powered features via the Kaapi API."
+    },
+    {
+      "name": "OpenAI Conversations",
+      "item": [
+        {
+          "name": "Get Single Conversation By ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/openai-conversation/:conversation_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "openai-conversation",
+                ":conversation_id"
+              ],
+              "variable": [
+                {
+                  "key": "conversation_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Get a single conversation by its ID.\n\nReturns conversation details for the specified conversation ID within the current project.\n\n• Replace the `conversation_id` to actual conversation ID in URL."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Conversation By ID",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/openai-conversation/:conversation_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "openai-conversation",
+                ":conversation_id"
+              ],
+              "variable": [
+                {
+                  "key": "conversation_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Delete a conversation by its ID.\n\nPerforms a delete by marking the conversation as deleted. The conversation remains in the database but is hidden from listings.\n\n• Replace the `conversation_id` to actual conversation ID in URL."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Conversation By OpenAI Response ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/openai-conversation/response/:response_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "openai-conversation",
+                "response",
+                ":response_id"
+              ],
+              "variable": [
+                {
+                  "key": "response_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Get a conversation by its OpenAI response ID.\n\nRetrieves conversation details using the OpenAI Responses API response ID for lookup.\n\n• Replace the `response_id` to actual conversation ID in URL."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Conversation By Ancestor Response ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/openai-conversation/ancestor/:ancestor_response_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "openai-conversation",
+                "ancestor",
+                ":ancestor_response_id"
+              ],
+              "variable": [
+                {
+                  "key": "ancestor_response_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Get a conversation by its ancestor response ID.\n\nRetrieves conversation details using the ancestor response ID for conversation chain lookup.\n\n• Replace the `ancestor_response_id` to actual conversation ID in URL."
+          },
+          "response": []
+        },
+        {
+          "name": "List All Conversations in Current Project",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/openai-conversation/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "openai-conversation",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "skip",
+                  "value": "0",
+                  "description": "How many items to skip",
+                  "type": "text",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "100",
+                  "description": "Maximum items to return",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "List all conversations in the current project.\n\nReturns paginated list of conversations with total count metadata for the current project."
+          },
+          "response": []
+        }
+      ],
+      "description": "Contains endpoints for managing multi-turn conversations with OpenAI models. Supports creating conversation sessions, sending messages, and retrieving conversation history."
+    },
+    {
+      "name": "Projects",
+      "item": [
+        {
+          "name": "Read Projects",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/projects/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "projects",
+                ""
+              ]
+            },
+            "description": "Retrieves a list of all projects accessible to the authenticated user. Returns project details including name, description, organization, and active status."
+          },
+          "response": []
+        },
+        {
+          "name": "Create New Project",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"\",\n    \"description\": \"\",\n    \"is_active\": true,\n    \"organization_id\": 0\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/projects/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "projects",
+                ""
+              ]
+            },
+            "description": "Creates a new project on the Kaapi platform. Accepts a JSON body with the following fields:\n- `name` (string): The name of the project.\n- `description` (string): A brief description of the project.\n- `is_active` (boolean): Whether the project is active.\n- `organization_id` (integer): The ID of the organization this project belongs to."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Project By ID",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/projects/:project_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "projects",
+                ":project_id"
+              ],
+              "variable": [
+                {
+                  "key": "project_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Retrieves the details of a specific project by its ID. Returns project information including name, description, organization, and active status. Accepts the following query parameter:\\n- `project_id` (integer): The unique ID of the project to retrieve."
+          },
+          "response": []
+        },
+        {
+          "name": "Update Project",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"\",\n    \"description\": \"\",\n    \"is_active\": true\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/projects/:project_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "projects",
+                ":project_id"
+              ],
+              "variable": [
+                {
+                  "key": "project_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Updates the details of an existing project. Accepts the following query parameter:\\n- `project_id` (integer): The unique ID of the project to update.\\n\\nAccepts a JSON body with the following fields:\\n- `name` (string): The updated name of the project.\\n- `description` (string): The updated description of the project.\\n- `is_active` (boolean): Whether the project is active."
+          },
+          "response": []
+        },
+        {
+          "name": "Read Project By Orgnization",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/projects/organization/:org_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "projects",
+                "organization",
+                ":org_id"
+              ],
+              "variable": [
+                {
+                  "key": "org_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Retrieves all projects belonging to a specific organization. Accepts the following query parameter:\\n- `org_id` (integer): The unique ID of the organization whose projects should be listed.\\n\\nReturns a list of projects associated with the given organization."
+          },
+          "response": []
+        }
+      ],
+      "description": "Covers full CRUD operations for projects within the Kaapi platform. Includes endpoints to create, read, update, and list projects, as well as retrieve projects scoped to a specific organization."
+    },
+    {
+      "name": "User Management",
+      "item": [
+        {
+          "name": "User Me",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/users/me",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "users",
+                "me"
+              ]
+            },
+            "description": "Retrieves the profile information of the currently authenticated user. Use this endpoint to fetch details such as name, email, and account settings for the logged-in user."
+          },
+          "response": []
+        },
+        {
+          "name": "Delete User Me",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/users/me",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "users",
+                "me"
+              ]
+            },
+            "description": "Permanently deletes the account of the currently authenticated user. This action is irreversible and will remove all associated data for the logged-in user from the platform."
+          },
+          "response": []
+        },
+        {
+          "name": "Update User Me",
+          "request": {
+            "method": "PATCH",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"full_name\": \"Test\",\n    \"email\": \"user@example.com\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/users/me",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "users",
+                "me"
+              ]
+            },
+            "description": "Updates the profile information of the currently authenticated user. Use this endpoint to modify details such as name, email, or other account settings for the logged-in user."
+          },
+          "response": []
+        },
+        {
+          "name": "Update Password Me",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"current_password\": \"Test\",\n    \"new_password\": \"Test@123\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/users/me/password",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "users",
+                "me",
+                "password"
+              ]
+            },
+            "description": "Updates the password of the currently authenticated user. Use this endpoint to change the login password for the logged-in user's account by providing the current and new password."
+          },
+          "response": []
+        },
+        {
+          "name": "Register User",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"email\": \"user@example.com\",\n    \"password\": \"Test@123\",\n    \"full_name\": \"Test\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/users/signup",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "users",
+                "signup"
+              ]
+            },
+            "description": "Registers a new user account on the Kaapi platform. Use this endpoint to create a new user by providing the required signup details such as name, email, and password."
+          },
+          "response": []
+        }
+      ],
+      "description": "Provides endpoints for managing user accounts, including creating, retrieving, updating, and deactivating users. Supports role and permission management within the platform."
+    },
+    {
+      "name": "User-Project Management",
+      "item": [
+        {
+          "name": "List Project Users",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/user-projects/?project_id=1",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "user-projects",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "project_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "List all users that belong to a project.  \n**Query Parameters:**\n\n• `project_id` (required)**:** The ID of the project to list users for.\n\nReturns user details including their active status - users added via invitation will have `is_active: false` until they complete their first Google login."
+          },
+          "response": []
+        },
+        {
+          "name": "Add Project Users",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"organization_id\": 0,\n    \"project_id\": 0,\n    \"users\": [\n        {\n            \"email\": \"user@example.com\",\n            \"full_name\": \"string\"\n        }\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/user-projects/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "user-projects",
+                ""
+              ]
+            },
+            "description": "Add one or more users to a project by email. **Requires superuser access.**\n\n**Request Body:**\n\n- `organization_id` (required): The ID of the organization the project belongs to.\n    \n- `project_id` (required): The ID of the project to add users to.\n    \n- `users` (required): Array of user objects.\n    \n    - `email` (required): User's email address.\n        \n    - `full_name` (optional): User's full name.\n        \n\n**Examples:**\n\n- **Single user**: `{\"organization_id\": 1, \"project_id\": 1, \"users\": [{\"email\": \"user@gmail.com\", \"full_name\": \"User Name\"}]}`\n    \n- **Multiple users**: `{\"organization_id\": 1, \"project_id\": 1, \"users\": [{\"email\": \"a@gmail.com\"}, {\"email\": \"b@gmail.com\"}]}`\n    \n\n**Behavior per email:**\n\n- If the user does not exist, a new account is created with `is_active: false`. The user will be activated on their first Google login.\n    \n- If the user already exists and is already in this project, they are skipped.\n    \n- If the user exists but is not in this project, they are added."
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Project User",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/user-projects/:user_id/?project_id=1",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "user-projects",
+                ":user_id",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "project_id",
+                  "value": "1"
+                }
+              ],
+              "variable": [
+                {
+                  "key": "user_id",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Remove a user from a project. **Requires superuser access.**\n\n**Path Parameters:**\n\n- `user_id` (required): The ID of the user to remove.\n    \n\n**Query Parameters:**\n\n- `project_id` (required): The ID of the project to remove the user from.\n    \n\nThis only removes the user-project mapping — the user account itself is not deleted. You cannot remove yourself from a project."
+          },
+          "response": []
+        }
+      ],
+      "description": "Manages the association between users and projects. Includes endpoints to assign users to projects, update their roles within a project, and remove user-project relationships."
+    },
+    {
+      "name": "STT Evaluation",
+      "item": [
+        {
+          "name": "Getting Started — STT Evaluation",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                ""
+              ]
+            },
+            "description": "# Getting Started — STT (Speech-to-Text) Evaluation\n\nThis walkthrough takes you from zero to a completed STT-eval run using only API calls.\n\n## Lifecycle\n\n```\n[Upload audio (×N)] → [Create STT dataset] → [Start STT run] → [Poll status] → [Review results] → [Submit feedback]\n```\n\n## Step 1: Upload audio files\n\nOne call per file. Supported formats: `mp3`, `wav`, `flac`, `m4a`, `ogg`, `webm`. Max **200 MB** per file.\n\n```bash\ncurl -X POST \\\n  -H 'X-API-KEY: <API_KEY>' \\\n  -F 'file=@recording-01.mp3' \\\n  https://api-staging.kaapi.ai/api/v1/evaluations/stt/files\n```\n\nEach response returns a `file_id`. Collect all of them.\n\n## Step 2: Create the STT dataset\n\n```bash\ncurl -X POST \\\n  -H 'X-API-KEY: <API_KEY>' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"name\": \"hindi_call_center_v1\",\n    \"description\": \"100 samples from call-center recordings\",\n    \"language_id\": 5,\n    \"samples\": [\n      { \"file_id\": 7225, \"ground_truth\": \"hello how can I help you\" },\n      { \"file_id\": 7226, \"ground_truth\": \"my order number is 12345\" }\n    ]\n  }' \\\n  https://api-staging.kaapi.ai/api/v1/evaluations/stt/datasets\n```\n\n`language_id` can be looked up via the **Languages** folder.\n\n## Step 3: Start the STT run\n\nCurrently exactly one model is supported: `gemini-2.5-pro`.\n\n```bash\ncurl -X POST \\\n  -H 'X-API-KEY: <API_KEY>' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"run_name\": \"baseline_run_2024_q4\",\n    \"dataset_id\": 1909,\n    \"models\": [\"gemini-2.5-pro\"]\n  }' \\\n  https://api-staging.kaapi.ai/api/v1/evaluations/stt/runs\n```\n\n## Step 4: Poll for completion\n\nPoll every 30–60 seconds:\n\n```bash\ncurl -H 'X-API-KEY: <API_KEY>' \\\n  https://api-staging.kaapi.ai/api/v1/evaluations/stt/runs/<run_id>\n```\n\nStatus moves `pending → processing → completed | failed`.\n\n## Step 5: Review results\n\nOnce `completed`, the response includes `results`. Each result has a `transcription`, `score` (WER/CER/MER/WIL when ground truth is set), and per-result `status`.\n\n## Step 6: Submit human feedback\n\nFor each result you reviewed:\n\n```bash\ncurl -X PATCH \\\n  -H 'X-API-KEY: <API_KEY>' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"is_correct\": true, \"comment\": \"matches ground truth\"}' \\\n  https://api-staging.kaapi.ai/api/v1/evaluations/stt/results/<result_id>\n```\n\n## What's not supported yet\n\n- DELETE for STT datasets\n- Adding more samples to an existing dataset (create a new one instead)\n- Multiple STT models per run (single provider currently)\n- Bulk feedback in a single call\n\n## Troubleshooting\n\nSee the **Errors & Troubleshooting** item at the top of this collection.\n"
+          },
+          "response": []
+        },
+        {
+          "name": "Get STT result",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/stt/results/:result_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "stt",
+                "results",
+                ":result_id"
+              ],
+              "variable": [
+                {
+                  "key": "result_id",
+                  "value": "9127"
+                }
+              ]
+            },
+            "description": "Get a single STT transcription result by ID.\n\nReturns the generated transcription, the provider that produced it, the result status, evaluation metrics, human feedback fields, and any error message.\n\n**Path parameter**\n- `result_id` (integer, required)\n\n**Response shape**\n```json\n{\n  \"success\": true,\n  \"data\": {\n    \"id\": 5001,\n    \"transcription\": \"hello how can i help you\",\n    \"provider\": \"gemini-2.5-pro\",\n    \"status\": \"SUCCESS\",\n    \"score\": {\"wer\": 0.05, \"cer\": 0.02, \"mer\": 0.05, \"wil\": 0.08},\n    \"is_correct\": true,\n    \"comment\": \"matches ground truth\",\n    \"error_message\": null,\n    \"stt_sample_id\": 3001,\n    \"evaluation_run_id\": 1909\n  }\n}\n```\n\n**Status enum:** `PENDING`, `SUCCESS`, `FAILED`.\n\n**Score keys** (populated only when ground truth is set on the sample): `wer` (word error rate), `cer` (character error rate), `mer` (match error rate), `wil` (word information lost). Lower is better.\n\n**Errors**\n- `404` — Result not found in this org/project\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/results/:result_id",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "results",
+                    ":result_id"
+                  ],
+                  "variable": [
+                    {
+                      "key": "result_id",
+                      "value": "9127"
+                    }
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": true,\n  \"data\": null,\n  \"error\": null,\n  \"errors\": [\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    },\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    }\n  ],\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": true,\n    \"key_2\": true\n  }\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/results/:result_id",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "results",
+                    ":result_id"
+                  ],
+                  "variable": [
+                    {
+                      "key": "result_id",
+                      "value": "9127"
+                    }
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        },
+        {
+          "name": "Update human feedback",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"is_correct\": false,\n  \"comment\": \"string\"\n}",
+              "options": {
+                "raw": {
+                  "headerFamily": "json",
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/stt/results/:result_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "stt",
+                "results",
+                ":result_id"
+              ],
+              "variable": [
+                {
+                  "key": "result_id",
+                  "value": "9127"
+                }
+              ]
+            },
+            "description": "Update human feedback on a single STT transcription result.\n\nUse this to mark a transcription as correct/incorrect and leave a comment. Feedback is **idempotent** — calling the endpoint twice with the same body produces the same result.\n\n**Path parameter**\n- `result_id` (integer, required)\n\n**Request body** — both fields optional; only provided fields are updated.\n```json\n{\n  \"is_correct\": true,\n  \"comment\": \"matches ground truth, no issues\"\n}\n```\n\nSend `\"is_correct\": null` to clear an existing review.\n\n**Errors**\n- `404` — Result not found in this org/project\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "PATCH",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"is_correct\": false,\n  \"comment\": \"string\"\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/results/:result_id",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "results",
+                    ":result_id"
+                  ],
+                  "variable": [
+                    {
+                      "key": "result_id",
+                      "value": "9127"
+                    }
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": true,\n  \"data\": null,\n  \"error\": null,\n  \"errors\": [\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    },\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    }\n  ],\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": true,\n    \"key_2\": true\n  }\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "PATCH",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"is_correct\": false,\n  \"comment\": \"string\"\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/results/:result_id",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "results",
+                    ":result_id"
+                  ],
+                  "variable": [
+                    {
+                      "key": "result_id",
+                      "value": "9127"
+                    }
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        },
+        {
+          "name": "Get STT evaluation run",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/stt/runs/:run_id?include_results=true&include_signed_url=false&result_limit=100&result_offset=0&provider=string&status=string",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "stt",
+                "runs",
+                ":run_id"
+              ],
+              "query": [
+                {
+                  "key": "include_results",
+                  "value": "true",
+                  "description": "Include results in response"
+                },
+                {
+                  "key": "include_signed_url",
+                  "value": "false",
+                  "description": "Include signed URLs for audio file samples"
+                },
+                {
+                  "key": "result_limit",
+                  "value": "100",
+                  "description": "Max results to return"
+                },
+                {
+                  "key": "result_offset",
+                  "value": "0",
+                  "description": "Result offset"
+                },
+                {
+                  "key": "provider",
+                  "value": "string",
+                  "description": "Filter results by provider"
+                },
+                {
+                  "key": "status",
+                  "value": "string",
+                  "description": "Filter results by status"
+                }
+              ],
+              "variable": [
+                {
+                  "key": "run_id",
+                  "value": "6803"
+                }
+              ]
+            },
+            "description": "Get a single STT evaluation run, optionally with its results.\n\nUse this endpoint to **poll** an in-flight run (status updates) and to fetch results once `status == completed`.\n\n**Polling guidance:** Evaluation runs are processed asynchronously by a background worker. Poll this endpoint every 30–60 seconds until `status` is `completed` or `failed`. Do not poll faster than once per 5 seconds.\n\n**Status lifecycle:** `pending` → `processing` → `completed` | `failed`.\n\n**Path parameter**\n- `run_id` (integer, required)\n\n**Query parameters**\n- `include_results` (optional, default `true`)\n- `include_signed_url` (optional, default `false`) — add 1-hour signed URLs for each result's source audio file\n- `result_limit` (optional, integer, 1–1000, default `100`)\n- `result_offset` (optional, integer, ≥0, default `0`)\n- `provider` (optional, string) — filter results by provider\n- `status` (optional, string) — filter results by per-result status (`PENDING`, `SUCCESS`, `FAILED`)\n\n**Reading a failed run**\nWhen `status == failed`, read the run's top-level `error_message`. Individual result-level failures are reported on each `STTResult` object's `error_message` field.\n\n**Errors**\n- `404` — Run not found in this org/project\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/runs/:run_id?include_results=true&include_signed_url=false&result_limit=100&result_offset=0&provider=string&status=string",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "runs",
+                    ":run_id"
+                  ],
+                  "query": [
+                    {
+                      "description": "Include results in response",
+                      "key": "include_results",
+                      "value": "true"
+                    },
+                    {
+                      "description": "Include signed URLs for audio file samples",
+                      "key": "include_signed_url",
+                      "value": "false"
+                    },
+                    {
+                      "description": "Max results to return",
+                      "key": "result_limit",
+                      "value": "100"
+                    },
+                    {
+                      "description": "Result offset",
+                      "key": "result_offset",
+                      "value": "0"
+                    },
+                    {
+                      "description": "Filter results by provider",
+                      "key": "provider",
+                      "value": "string"
+                    },
+                    {
+                      "description": "Filter results by status",
+                      "key": "status",
+                      "value": "string"
+                    }
+                  ],
+                  "variable": [
+                    {
+                      "key": "run_id",
+                      "value": "6803"
+                    }
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": true,\n  \"data\": {\n    \"id\": 8818,\n    \"run_name\": \"string\",\n    \"dataset_name\": \"string\",\n    \"type\": \"string\",\n    \"language_id\": 4878,\n    \"models\": null,\n    \"dataset_id\": 1506,\n    \"status\": \"string\",\n    \"total_items\": 8033,\n    \"score\": null,\n    \"error_message\": \"string\",\n    \"organization_id\": 6747,\n    \"project_id\": 9122,\n    \"inserted_at\": \"2020-03-06T05:27:29.079Z\",\n    \"updated_at\": \"1986-09-24T09:11:40.263Z\",\n    \"results\": [\n      {\n        \"id\": 3090,\n        \"transcription\": \"string\",\n        \"provider\": \"string\",\n        \"status\": \"string\",\n        \"score\": null,\n        \"is_correct\": true,\n        \"comment\": null,\n        \"error_message\": null,\n        \"stt_sample_id\": 5094,\n        \"evaluation_run_id\": 7703,\n        \"organization_id\": 1514,\n        \"project_id\": 7789,\n        \"inserted_at\": \"1956-07-18T17:43:26.671Z\",\n        \"updated_at\": \"2023-02-27T03:15:23.285Z\",\n        \"sample\": {\n          \"id\": 7566,\n          \"file_id\": 6991,\n          \"language_id\": null,\n          \"ground_truth\": null,\n          \"sample_metadata\": null,\n          \"dataset_id\": 4414,\n          \"organization_id\": 5317,\n          \"project_id\": 2020,\n          \"inserted_at\": \"1976-08-28T12:17:11.486Z\",\n          \"updated_at\": \"1956-11-01T22:11:46.789Z\",\n          \"object_store_url\": \"string\",\n          \"signed_url\": \"string\"\n        }\n      },\n      {\n        \"id\": 100,\n        \"transcription\": \"string\",\n        \"provider\": \"string\",\n        \"status\": \"string\",\n        \"score\": {\n          \"key_0\": \"string\"\n        },\n        \"is_correct\": false,\n        \"comment\": \"string\",\n        \"error_message\": null,\n        \"stt_sample_id\": 7629,\n        \"evaluation_run_id\": 1275,\n        \"organization_id\": 1455,\n        \"project_id\": 2141,\n        \"inserted_at\": \"1986-06-30T02:43:54.103Z\",\n        \"updated_at\": \"1970-06-11T14:48:49.188Z\",\n        \"sample\": {\n          \"id\": 1935,\n          \"file_id\": 9708,\n          \"language_id\": 576,\n          \"ground_truth\": null,\n          \"sample_metadata\": null,\n          \"dataset_id\": 8873,\n          \"organization_id\": 3442,\n          \"project_id\": 5804,\n          \"inserted_at\": \"2000-05-03T06:59:02.053Z\",\n          \"updated_at\": \"2015-10-18T04:30:12.232Z\",\n          \"object_store_url\": null,\n          \"signed_url\": \"string\"\n        }\n      }\n    ],\n    \"results_total\": 0\n  },\n  \"error\": \"string\",\n  \"errors\": null,\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4486\n  }\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/runs/:run_id?include_results=true&include_signed_url=false&result_limit=100&result_offset=0&provider=string&status=string",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "runs",
+                    ":run_id"
+                  ],
+                  "query": [
+                    {
+                      "description": "Include results in response",
+                      "key": "include_results",
+                      "value": "true"
+                    },
+                    {
+                      "description": "Include signed URLs for audio file samples",
+                      "key": "include_signed_url",
+                      "value": "false"
+                    },
+                    {
+                      "description": "Max results to return",
+                      "key": "result_limit",
+                      "value": "100"
+                    },
+                    {
+                      "description": "Result offset",
+                      "key": "result_offset",
+                      "value": "0"
+                    },
+                    {
+                      "description": "Filter results by provider",
+                      "key": "provider",
+                      "value": "string"
+                    },
+                    {
+                      "description": "Filter results by status",
+                      "key": "status",
+                      "value": "string"
+                    }
+                  ],
+                  "variable": [
+                    {
+                      "key": "run_id",
+                      "value": "6803"
+                    }
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        },
+        {
+          "name": "List STT evaluation runs",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/stt/runs?dataset_id=8342&status=string&limit=50&offset=0",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "stt",
+                "runs"
+              ],
+              "query": [
+                {
+                  "key": "dataset_id",
+                  "value": "8342",
+                  "description": "Filter by dataset ID"
+                },
+                {
+                  "key": "status",
+                  "value": "string",
+                  "description": "Filter by status"
+                },
+                {
+                  "key": "limit",
+                  "value": "50",
+                  "description": "Maximum results to return"
+                },
+                {
+                  "key": "offset",
+                  "value": "0",
+                  "description": "Number of results to skip"
+                }
+              ]
+            },
+            "description": "List all STT evaluation runs for the current project.\n\nReturns each run with ID, name, dataset reference, language, models, status, total items, score (when complete), and timestamps. Use the result to find specific runs to inspect.\n\n**Query parameters**\n- `dataset_id` (optional, integer) — filter to one dataset\n- `status` (optional, string) — one of `pending`, `processing`, `completed`, `failed`\n- `limit` (optional, integer, 1–100, default `50`)\n- `offset` (optional, integer, ≥0, default `0`)\n\n**Status enum:** `pending` → `processing` → `completed` | `failed`.\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/runs?dataset_id=8342&status=string&limit=50&offset=0",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "runs"
+                  ],
+                  "query": [
+                    {
+                      "description": "Filter by dataset ID",
+                      "key": "dataset_id",
+                      "value": "8342"
+                    },
+                    {
+                      "description": "Filter by status",
+                      "key": "status",
+                      "value": "string"
+                    },
+                    {
+                      "description": "Maximum results to return",
+                      "key": "limit",
+                      "value": "50"
+                    },
+                    {
+                      "description": "Number of results to skip",
+                      "key": "offset",
+                      "value": "0"
+                    }
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": true,\n  \"data\": null,\n  \"error\": \"string\",\n  \"errors\": null,\n  \"metadata\": {\n    \"key_0\": 5889.757610242536\n  }\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/runs?dataset_id=8342&status=string&limit=50&offset=0",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "runs"
+                  ],
+                  "query": [
+                    {
+                      "description": "Filter by dataset ID",
+                      "key": "dataset_id",
+                      "value": "8342"
+                    },
+                    {
+                      "description": "Filter by status",
+                      "key": "status",
+                      "value": "string"
+                    },
+                    {
+                      "description": "Maximum results to return",
+                      "key": "limit",
+                      "value": "50"
+                    },
+                    {
+                      "description": "Number of results to skip",
+                      "key": "offset",
+                      "value": "0"
+                    }
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        },
+        {
+          "name": "Start STT evaluation",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"run_name\": \"baseline_run_2024_q4\",\n  \"dataset_id\": 1909,\n  \"models\": [\"gemini-2.5-pro\"]\n}",
+              "options": {
+                "raw": {
+                  "headerFamily": "json",
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/stt/runs",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "stt",
+                "runs"
+              ]
+            },
+            "description": "Start an STT evaluation run on an existing STT dataset.\n\nEach audio sample is transcribed by every requested model in parallel via the Gemini Batch API. Results are stored for human review.\n\n**Authentication:** All Evaluation endpoints require the `X-API-KEY` header (configured at the collection level via the `{{API_KEY}}` variable). Requests are scoped to the organization and project that own the API key.\n\n**Prerequisites**\n1. Create an STT dataset via **Create STT dataset** (and upload audio files first).\n\n**Request body**\n- `run_name` (string, required, min 1 char)\n- `dataset_id` (integer, required)\n- `models` (array of strings, required, min 1) — currently exactly **one** value is supported: `gemini-2.5-pro`\n\n**Example**\n```json\n{\n  \"run_name\": \"baseline_run_2024_q4\",\n  \"dataset_id\": 1909,\n  \"models\": [\"gemini-2.5-pro\"]\n}\n```\n\n**Supported providers (current):** `gemini-2.5-pro`\n\n**Polling guidance:** Evaluation runs are processed asynchronously by a background worker. Poll this endpoint every 30–60 seconds until `status` is `completed` or `failed`. Do not poll faster than once per 5 seconds.\n\n**Status lifecycle:** `pending` → `processing` → `completed` | `failed`.\n\n**Errors specific to this endpoint**\n- `404` — Dataset not found in this org/project\n- `400` — Dataset has no samples\n- `422` — One or more `models` values are not in the supported list\n- `500` — Failed to enqueue the batch submission (Celery / Gemini upload)\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"run_name\": \"string\",\n  \"dataset_id\": 1909,\n  \"models\": [\n    \"string\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/runs",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "runs"
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": false,\n  \"data\": null,\n  \"error\": null,\n  \"errors\": null,\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 2540.1044702773156\n  }\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"run_name\": \"string\",\n  \"dataset_id\": 1909,\n  \"models\": [\n    \"string\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/runs",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "runs"
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        },
+        {
+          "name": "Update STT sample",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"language_id\": 5,\n  \"ground_truth\": \"corrected transcription text\"\n}",
+              "options": {
+                "raw": {
+                  "headerFamily": "json",
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/stt/samples/:sample_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "stt",
+                "samples",
+                ":sample_id"
+              ],
+              "variable": [
+                {
+                  "key": "sample_id",
+                  "value": "333"
+                }
+              ]
+            },
+            "description": "Update an STT sample's language and/or ground-truth transcription.\n\nUse this to correct ground truth (used by WER/CER metrics) or change the sample's language after dataset creation.\n\n**Path parameter**\n- `sample_id` (integer, required)\n\n**Request body** — only the provided fields are updated. Sending `null` for a field clears it; omitting a field leaves it unchanged.\n```json\n{\n  \"language_id\": 5,\n  \"ground_truth\": \"corrected transcription text\"\n}\n```\n\n**Errors**\n- `404` — Sample not found, or `language_id` does not exist\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "PATCH",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"language_id\": null,\n  \"ground_truth\": \"string\"\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/samples/:sample_id",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "samples",
+                    ":sample_id"
+                  ],
+                  "variable": [
+                    {
+                      "key": "sample_id",
+                      "value": "333"
+                    }
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": false,\n  \"data\": {\n    \"id\": 2991,\n    \"file_id\": 3706,\n    \"language_id\": 7091,\n    \"ground_truth\": \"string\",\n    \"sample_metadata\": null,\n    \"dataset_id\": 1997,\n    \"organization_id\": 637,\n    \"project_id\": 1929,\n    \"inserted_at\": \"1970-01-12T03:22:22.462Z\",\n    \"updated_at\": \"1948-06-02T10:18:38.105Z\",\n    \"object_store_url\": \"string\",\n    \"signed_url\": \"string\"\n  },\n  \"error\": \"string\",\n  \"errors\": [\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    },\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    }\n  ],\n  \"metadata\": {\n    \"key_0\": 8761,\n    \"key_1\": false,\n    \"key_2\": 9899\n  }\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "PATCH",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"language_id\": null,\n  \"ground_truth\": \"string\"\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/samples/:sample_id",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "samples",
+                    ":sample_id"
+                  ],
+                  "variable": [
+                    {
+                      "key": "sample_id",
+                      "value": "333"
+                    }
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        },
+        {
+          "name": "List STT datasets",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/stt/datasets?limit=50&offset=0",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "stt",
+                "datasets"
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "50",
+                  "description": "Maximum results to return"
+                },
+                {
+                  "key": "offset",
+                  "value": "0",
+                  "description": "Number of results to skip"
+                }
+              ]
+            },
+            "description": "List all STT evaluation datasets for the current project.\n\nReturns each dataset with its ID, name, type, language, object store URL, sample count, and timestamps. Use the resulting `dataset_id` when starting an STT evaluation run.\n\n**Query parameters**\n- `limit` (optional, integer, 1–100, default `50`)\n- `offset` (optional, integer, ≥0, default `0`)\n\n**Response metadata** includes `total`, `limit`, `offset` for pagination.\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/datasets?limit=50&offset=0",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "datasets"
+                  ],
+                  "query": [
+                    {
+                      "description": "Maximum results to return",
+                      "key": "limit",
+                      "value": "50"
+                    },
+                    {
+                      "description": "Number of results to skip",
+                      "key": "offset",
+                      "value": "0"
+                    }
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": false,\n  \"data\": null,\n  \"error\": \"string\",\n  \"errors\": null,\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 4410.07840255915,\n    \"key_2\": 6873\n  }\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/datasets?limit=50&offset=0",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "datasets"
+                  ],
+                  "query": [
+                    {
+                      "description": "Maximum results to return",
+                      "key": "limit",
+                      "value": "50"
+                    },
+                    {
+                      "description": "Number of results to skip",
+                      "key": "offset",
+                      "value": "0"
+                    }
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        },
+        {
+          "name": "Create STT dataset",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"hindi_call_center_v1\",\n  \"description\": \"100 samples from call-center recordings\",\n  \"language_id\": 5,\n  \"samples\": [\n    { \"file_id\": 7225, \"ground_truth\": \"hello how can I help you\" }\n  ]\n}",
+              "options": {
+                "raw": {
+                  "headerFamily": "json",
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/stt/datasets",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "stt",
+                "datasets"
+              ]
+            },
+            "description": "Create a new STT evaluation dataset from previously uploaded audio files.\n\nEach sample references a `file_id` returned by **Upload audio file**. Each sample can optionally include a ground-truth transcription (used for WER/CER metrics) and override the dataset language.\n\n**Authentication:** All Evaluation endpoints require the `X-API-KEY` header (configured at the collection level via the `{{API_KEY}}` variable). Requests are scoped to the organization and project that own the API key.\n\n**Prerequisites**\n1. Upload each audio file via **Upload audio file** and collect the `file_id` values.\n2. (Optional) Find the language ID for your samples via the `Languages` folder's `List Languages` endpoint.\n\n**Request body**\n- `name` (string, required, min 1 char) — unique within org/project\n- `description` (string, optional)\n- `language_id` (integer, optional) — default language for all samples; individual samples can override\n- `samples` (array, required, min 1) — list of `{file_id, ground_truth?, language_id?}` objects\n\n**Example**\n```json\n{\n  \"name\": \"hindi_call_center_v1\",\n  \"description\": \"100 samples from call-center recordings\",\n  \"language_id\": 5,\n  \"samples\": [\n    { \"file_id\": 7225, \"ground_truth\": \"hello how can I help you\" },\n    { \"file_id\": 7226, \"ground_truth\": \"my order number is 12345\" }\n  ]\n}\n```\n\n**Errors specific to this endpoint**\n- `400` — One or more `file_id` values are not found in this org/project\n- `400` — Dataset name already exists in this org/project\n- `404` — Provided `language_id` does not exist\n- `422` — `samples` is empty or `name` is empty\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"name\": \"string\",\n  \"samples\": [\n    {\n      \"file_id\": 7225,\n      \"ground_truth\": \"string\",\n      \"language_id\": 8609\n    }\n  ],\n  \"description\": \"string\",\n  \"language_id\": null\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/datasets",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "datasets"
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": false,\n  \"data\": {\n    \"id\": 8757,\n    \"name\": \"string\",\n    \"description\": null,\n    \"type\": \"string\",\n    \"language_id\": 2457,\n    \"object_store_url\": null,\n    \"dataset_metadata\": {\n      \"key_0\": false\n    },\n    \"organization_id\": 8837,\n    \"project_id\": 2253,\n    \"inserted_at\": \"2007-06-10T21:24:06.322Z\",\n    \"updated_at\": \"1983-02-24T00:49:26.124Z\"\n  },\n  \"error\": null,\n  \"errors\": [\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    },\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    }\n  ],\n  \"metadata\": null\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"name\": \"string\",\n  \"samples\": [\n    {\n      \"file_id\": 7225,\n      \"ground_truth\": \"string\",\n      \"language_id\": 8609\n    }\n  ],\n  \"description\": \"string\",\n  \"language_id\": null\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/datasets",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "datasets"
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        },
+        {
+          "name": "Get STT dataset",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/stt/datasets/:dataset_id?include_samples=true&include_signed_url=false&sample_limit=100&sample_offset=0",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "stt",
+                "datasets",
+                ":dataset_id"
+              ],
+              "query": [
+                {
+                  "key": "include_samples",
+                  "value": "true",
+                  "description": "Include samples in response"
+                },
+                {
+                  "key": "include_signed_url",
+                  "value": "false",
+                  "description": "Include signed URLs for audio file samples"
+                },
+                {
+                  "key": "sample_limit",
+                  "value": "100",
+                  "description": "Max samples to return"
+                },
+                {
+                  "key": "sample_offset",
+                  "value": "0",
+                  "description": "Sample offset"
+                }
+              ],
+              "variable": [
+                {
+                  "key": "dataset_id",
+                  "value": "6473"
+                }
+              ]
+            },
+            "description": "Get an STT evaluation dataset by ID, optionally with its samples.\n\nReturns dataset metadata. Samples are included by default and can be paginated. Signed URLs for each sample's audio file are available on request.\n\n**Path parameter**\n- `dataset_id` (integer, required)\n\n**Query parameters**\n- `include_samples` (optional, default `true`) — embed samples in the response\n- `include_signed_url` (optional, default `false`) — add 1-hour signed URLs for each sample's audio file\n- `sample_limit` (optional, integer, 1–1000, default `100`)\n- `sample_offset` (optional, integer, ≥0, default `0`)\n\n**Errors**\n- `404` — Dataset not found in this org/project\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/datasets/:dataset_id?include_samples=true&include_signed_url=false&sample_limit=100&sample_offset=0",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "datasets",
+                    ":dataset_id"
+                  ],
+                  "query": [
+                    {
+                      "description": "Include samples in response",
+                      "key": "include_samples",
+                      "value": "true"
+                    },
+                    {
+                      "description": "Include signed URLs for audio file samples",
+                      "key": "include_signed_url",
+                      "value": "false"
+                    },
+                    {
+                      "description": "Max samples to return",
+                      "key": "sample_limit",
+                      "value": "100"
+                    },
+                    {
+                      "description": "Sample offset",
+                      "key": "sample_offset",
+                      "value": "0"
+                    }
+                  ],
+                  "variable": [
+                    {
+                      "key": "dataset_id",
+                      "value": "6473"
+                    }
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": false,\n  \"data\": {\n    \"id\": 3881,\n    \"name\": \"string\",\n    \"description\": null,\n    \"type\": \"string\",\n    \"language_id\": 1149,\n    \"object_store_url\": \"string\",\n    \"dataset_metadata\": {\n      \"key_0\": true,\n      \"key_1\": 7847\n    },\n    \"organization_id\": 6763,\n    \"project_id\": 8676,\n    \"inserted_at\": \"2007-11-13T04:17:49.599Z\",\n    \"updated_at\": \"1971-07-26T02:32:57.217Z\",\n    \"samples\": [\n      {\n        \"id\": 1294,\n        \"file_id\": 3420,\n        \"language_id\": null,\n        \"ground_truth\": \"string\",\n        \"sample_metadata\": null,\n        \"dataset_id\": 8731,\n        \"organization_id\": 7831,\n        \"project_id\": 8315,\n        \"inserted_at\": \"2017-12-06T01:25:23.950Z\",\n        \"updated_at\": \"1978-01-11T13:17:05.914Z\",\n        \"object_store_url\": null,\n        \"signed_url\": null\n      },\n      {\n        \"id\": 4278,\n        \"file_id\": 7335,\n        \"language_id\": 1259,\n        \"ground_truth\": \"string\",\n        \"sample_metadata\": null,\n        \"dataset_id\": 1141,\n        \"organization_id\": 2755,\n        \"project_id\": 3689,\n        \"inserted_at\": \"2000-08-04T09:40:26.128Z\",\n        \"updated_at\": \"1990-04-17T04:07:28.386Z\",\n        \"object_store_url\": \"string\",\n        \"signed_url\": null\n      }\n    ]\n  },\n  \"error\": null,\n  \"errors\": [\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    },\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    }\n  ],\n  \"metadata\": {\n    \"key_0\": false,\n    \"key_1\": \"string\",\n    \"key_2\": false\n  }\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/datasets/:dataset_id?include_samples=true&include_signed_url=false&sample_limit=100&sample_offset=0",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "datasets",
+                    ":dataset_id"
+                  ],
+                  "query": [
+                    {
+                      "description": "Include samples in response",
+                      "key": "include_samples",
+                      "value": "true"
+                    },
+                    {
+                      "description": "Include signed URLs for audio file samples",
+                      "key": "include_signed_url",
+                      "value": "false"
+                    },
+                    {
+                      "description": "Max samples to return",
+                      "key": "sample_limit",
+                      "value": "100"
+                    },
+                    {
+                      "description": "Sample offset",
+                      "key": "sample_offset",
+                      "value": "0"
+                    }
+                  ],
+                  "variable": [
+                    {
+                      "key": "dataset_id",
+                      "value": "6473"
+                    }
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        },
+        {
+          "name": "List audio files",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/stt/files?include_signed_url=false",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "stt",
+                "files"
+              ],
+              "query": [
+                {
+                  "key": "include_signed_url",
+                  "value": "false",
+                  "description": "Include a signed URL to access the audio file"
+                }
+              ]
+            },
+            "description": "List all audio files uploaded for the current project.\n\nReturns metadata for each file (file ID, filename, size, content type, timestamps). Use this to look up file IDs before creating a dataset.\n\n**Query parameter**\n- `include_signed_url` (optional, default `false`) — when `true`, every entry includes a signed URL valid for **1 hour** for direct download.\n\n**Response shape**\n```json\n{\n  \"success\": true,\n  \"data\": [\n    {\n      \"id\": 7225,\n      \"filename\": \"recording-01.mp3\",\n      \"size_bytes\": 1048576,\n      \"content_type\": \"audio/mp3\",\n      \"object_store_url\": \"s3://...\",\n      \"signed_url\": \"https://...?X-Amz-Expires=3600...\"\n    }\n  ]\n}\n```\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/files?include_signed_url=false",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "files"
+                  ],
+                  "query": [
+                    {
+                      "description": "Include a signed URL to access the audio file",
+                      "key": "include_signed_url",
+                      "value": "false"
+                    }
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": false,\n  \"data\": [\n    {\n      \"id\": 5342,\n      \"object_store_url\": \"string\",\n      \"filename\": \"string\",\n      \"size_bytes\": 3619,\n      \"content_type\": \"string\",\n      \"file_type\": \"string\",\n      \"organization_id\": 1316,\n      \"project_id\": 7148,\n      \"inserted_at\": \"1963-10-19T04:06:04.653Z\",\n      \"updated_at\": \"2015-05-26T00:46:08.189Z\",\n      \"signed_url\": \"string\"\n    },\n    {\n      \"id\": 6052,\n      \"object_store_url\": \"string\",\n      \"filename\": \"string\",\n      \"size_bytes\": 1265,\n      \"content_type\": \"string\",\n      \"file_type\": \"string\",\n      \"organization_id\": 5324,\n      \"project_id\": 9282,\n      \"inserted_at\": \"2002-02-22T18:57:35.138Z\",\n      \"updated_at\": \"1957-02-24T21:26:29.384Z\",\n      \"signed_url\": null\n    }\n  ],\n  \"error\": \"string\",\n  \"errors\": [\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    },\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    }\n  ],\n  \"metadata\": null\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/files?include_signed_url=false",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "files"
+                  ],
+                  "query": [
+                    {
+                      "description": "Include a signed URL to access the audio file",
+                      "key": "include_signed_url",
+                      "value": "false"
+                    }
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        },
+        {
+          "name": "Upload audio file",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "multipart/form-data"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "description": "Audio file to upload",
+                  "key": "file",
+                  "type": "file",
+                  "src": ""
+                }
+              ]
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/stt/files",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "stt",
+                "files"
+              ]
+            },
+            "description": "Upload a single audio file to object storage for STT (Speech-to-Text) evaluation. Returns the file ID and storage URL.\n\n**Authentication:** All Evaluation endpoints require the `X-API-KEY` header (configured at the collection level via the `{{API_KEY}}` variable). Requests are scoped to the organization and project that own the API key.\n\n**Supported formats**\n`mp3`, `wav`, `flac`, `m4a`, `ogg`, `webm`\n\n**Limits**\n- Maximum file size: **200 MB**\n- File extension is required and must match the supported list (case-insensitive)\n\n**Form field**\n- `file` (required, file)\n\n**Sample cURL**\n```bash\ncurl -X POST \\\n  -H 'X-API-KEY: <your-api-key>' \\\n  -F 'file=@/path/to/audio.mp3' \\\n  https://api-staging.kaapi.ai/api/v1/evaluations/stt/files\n```\n\n**Response**\n```json\n{\n  \"success\": true,\n  \"data\": {\n    \"file_id\": 7225,\n    \"s3_url\": \"s3://bucket/stt/audio/<uuid>.mp3\",\n    \"filename\": \"recording-01.mp3\",\n    \"size_bytes\": 1048576,\n    \"content_type\": \"audio/mp3\"\n  }\n}\n```\n\n**Next step:** Use the returned `file_id` when creating an STT dataset via **Create STT dataset**.\n\n**Errors specific to this endpoint**\n- `400` — Filename missing, unsupported format, or file > 200 MB\n- `500` — Object storage upload failed\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "multipart/form-data"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "description": "Audio file to upload",
+                      "key": "file",
+                      "value": "string",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/files",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "files"
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": false,\n  \"data\": null,\n  \"error\": \"string\",\n  \"errors\": [\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    },\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    }\n  ],\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 9595.838013278923,\n    \"key_2\": 5219\n  }\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "multipart/form-data"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "description": "Audio file to upload",
+                      "key": "file",
+                      "value": "string",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/files",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "files"
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        },
+        {
+          "name": "Get audio file by ID",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/stt/files/:file_id?include_signed_url=false",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "stt",
+                "files",
+                ":file_id"
+              ],
+              "query": [
+                {
+                  "key": "include_signed_url",
+                  "value": "false",
+                  "description": "Include a signed URL to access the audio file"
+                }
+              ],
+              "variable": [
+                {
+                  "key": "file_id",
+                  "value": "5645"
+                }
+              ]
+            },
+            "description": "Retrieve metadata for a single audio file by its ID.\n\nReturns file location, size, content type, and timestamps. Optionally includes a signed URL for direct access.\n\n**Path parameter**\n- `file_id` (integer, required)\n\n**Query parameter**\n- `include_signed_url` (optional, default `false`) — adds a signed URL valid for **1 hour**.\n\n**Errors**\n- `404` — File not found in this org/project\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/files/:file_id?include_signed_url=false",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "files",
+                    ":file_id"
+                  ],
+                  "query": [
+                    {
+                      "description": "Include a signed URL to access the audio file",
+                      "key": "include_signed_url",
+                      "value": "false"
+                    }
+                  ],
+                  "variable": [
+                    {
+                      "key": "file_id",
+                      "value": "5645"
+                    }
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": true,\n  \"data\": null,\n  \"error\": null,\n  \"errors\": null,\n  \"metadata\": null\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/stt/files/:file_id?include_signed_url=false",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "stt",
+                    "files",
+                    ":file_id"
+                  ],
+                  "query": [
+                    {
+                      "description": "Include a signed URL to access the audio file",
+                      "key": "include_signed_url",
+                      "value": "false"
+                    }
+                  ],
+                  "variable": [
+                    {
+                      "key": "file_id",
+                      "value": "5645"
+                    }
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        }
+      ],
+      "description": "Contains endpoints for evaluating Speech-to-Text (STT) model outputs. Use these to submit audio transcription requests and assess the accuracy and quality of STT results."
+    },
+    {
+      "name": "TTS Evaluation",
+      "item": [
+        {
+          "name": "Getting Started — TTS Evaluation",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                ""
+              ]
+            },
+            "description": "# Getting Started — TTS (Text-to-Speech) Evaluation\n\nThis walkthrough takes you from zero to a completed TTS-eval run using only API calls.\n\n## Lifecycle\n\n```\n[Create TTS dataset] → [Start TTS run] → [Poll status] → [Review audio] → [Submit feedback]\n```\n\n## Step 1: Create the TTS dataset\n\nTexts only — no file uploads needed. Each sample text must be ≤ 5000 characters.\n\n```bash\ncurl -X POST \\\n  -H 'X-API-KEY: <API_KEY>' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"name\": \"customer_greetings_v1\",\n    \"description\": \"Greetings for support voicebot\",\n    \"language_id\": 5,\n    \"samples\": [\n      { \"text\": \"Welcome to Project Tech4Dev support. How may I help you today?\" },\n      { \"text\": \"Your request has been received. We will get back to you within 24 hours.\" }\n    ]\n  }' \\\n  https://api-staging.kaapi.ai/api/v1/evaluations/tts/datasets\n```\n\n## Step 2: Start the TTS run\n\nCurrently exactly one model is supported: `gemini-2.5-pro-preview-tts`. The default voice is `Kore` with a calm, professional customer-service style.\n\n```bash\ncurl -X POST \\\n  -H 'X-API-KEY: <API_KEY>' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"run_name\": \"voicebot_qa_2024_q4\",\n    \"dataset_id\": 7653,\n    \"models\": [\"gemini-2.5-pro-preview-tts\"]\n  }' \\\n  https://api-staging.kaapi.ai/api/v1/evaluations/tts/runs\n```\n\n## Step 3: Poll for completion\n\nPoll every 30–60 seconds:\n\n```bash\ncurl -H 'X-API-KEY: <API_KEY>' \\\n  https://api-staging.kaapi.ai/api/v1/evaluations/tts/runs/<run_id>\n```\n\n## Step 4: Review generated audio\n\nOnce `completed`, fetch the run with signed URLs to listen to each generated WAV:\n\n```bash\ncurl -H 'X-API-KEY: <API_KEY>' \\\n  'https://api-staging.kaapi.ai/api/v1/evaluations/tts/runs/<run_id>?include_signed_url=true'\n```\n\nEach result includes `object_store_url`, `signed_url` (1-hour TTL), `duration_seconds`, and `size_bytes`.\n\n## Step 5: Submit human feedback\n\n**Important:** feedback is only accepted on results whose `status` is `SUCCESS`. Calling PATCH on a `PENDING` or `FAILED` result returns 400.\n\n```bash\ncurl -X PATCH \\\n  -H 'X-API-KEY: <API_KEY>' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"is_correct\": true,\n    \"comment\": \"clear and natural\",\n    \"score\": {\n      \"Speech Naturalness\": \"high\",\n      \"Pronunciation Accuracy\": \"high\"\n    }\n  }' \\\n  https://api-staging.kaapi.ai/api/v1/evaluations/tts/results/<result_id>\n```\n\nThe `score` schema is **illustrative**, not enforced — you can use your own keys and values.\n\n## What's not supported yet\n\n- DELETE for TTS datasets\n- Voice / style-prompt customization per run via API\n- Multiple TTS models per run (single provider currently)\n- Cancel / retry a run\n\n## Troubleshooting\n\nSee the **Errors & Troubleshooting** item at the top of this collection.\n"
+          },
+          "response": []
+        },
+        {
+          "name": "Get TTS result",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/tts/results/:result_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "tts",
+                "results",
+                ":result_id"
+              ],
+              "query": [
+                {
+                  "key": "include_signed_url",
+                  "value": "false",
+                  "description": "Include signed URL for generated audio file",
+                  "disabled": true
+                }
+              ],
+              "variable": [
+                {
+                  "key": "result_id",
+                  "value": "9127"
+                }
+              ]
+            },
+            "description": "Get a single TTS synthesis result by ID.\n\nReturns the input text, the generated audio file URL, audio metadata (duration, size), provider, status, score, and human feedback fields.\n\n**Path parameter**\n- `result_id` (integer, required)\n\n**Query parameter**\n- `include_signed_url` (optional, default `false`) — adds a signed URL for the generated WAV file valid for **1 hour**.\n\n**Response shape**\n```json\n{\n  \"success\": true,\n  \"data\": {\n    \"id\": 8001,\n    \"sample_text\": \"Welcome to Project Tech4Dev support.\",\n    \"object_store_url\": \"s3://bucket/tts/result/<uuid>.wav\",\n    \"signed_url\": \"https://...\",\n    \"duration_seconds\": 3.42,\n    \"size_bytes\": 270000,\n    \"provider\": \"gemini-2.5-pro-preview-tts\",\n    \"status\": \"SUCCESS\",\n    \"score\": null,\n    \"is_correct\": null,\n    \"comment\": null,\n    \"error_message\": null,\n    \"evaluation_run_id\": 7653\n  }\n}\n```\n\n**Status enum:** `PENDING`, `SUCCESS`, `FAILED`.\n\n**Errors**\n- `404` — Result not found in this org/project\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/tts/results/:result_id?include_signed_url=false",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "tts",
+                    "results",
+                    ":result_id"
+                  ],
+                  "query": [
+                    {
+                      "description": "Include signed URL for generated audio file",
+                      "key": "include_signed_url",
+                      "value": "false"
+                    }
+                  ],
+                  "variable": [
+                    {
+                      "key": "result_id",
+                      "value": "9127"
+                    }
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": false,\n  \"data\": {\n    \"id\": 8953,\n    \"sample_text\": \"string\",\n    \"object_store_url\": null,\n    \"provider\": \"string\",\n    \"status\": \"string\",\n    \"score\": null,\n    \"is_correct\": null,\n    \"comment\": \"string\",\n    \"error_message\": null,\n    \"evaluation_run_id\": 5932,\n    \"organization_id\": 2636,\n    \"project_id\": 6676,\n    \"inserted_at\": \"1951-05-09T18:16:57.461Z\",\n    \"updated_at\": \"1947-02-28T09:13:16.081Z\",\n    \"signed_url\": null,\n    \"duration_seconds\": 4051.536105708464,\n    \"size_bytes\": null\n  },\n  \"error\": \"string\",\n  \"errors\": [\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    },\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    }\n  ],\n  \"metadata\": {\n    \"key_0\": 7876,\n    \"key_1\": 3642,\n    \"key_2\": 6033.581442702558\n  }\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/tts/results/:result_id?include_signed_url=false",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "tts",
+                    "results",
+                    ":result_id"
+                  ],
+                  "query": [
+                    {
+                      "description": "Include signed URL for generated audio file",
+                      "key": "include_signed_url",
+                      "value": "false"
+                    }
+                  ],
+                  "variable": [
+                    {
+                      "key": "result_id",
+                      "value": "9127"
+                    }
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        },
+        {
+          "name": "Get TTS evaluation run",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/tts/runs/:run_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "tts",
+                "runs",
+                ":run_id"
+              ],
+              "query": [
+                {
+                  "key": "include_results",
+                  "value": "true",
+                  "description": "Include results in response",
+                  "disabled": true
+                },
+                {
+                  "key": "include_signed_url",
+                  "value": "false",
+                  "description": "Include signed URLs for generated audio files",
+                  "disabled": true
+                }
+              ],
+              "variable": [
+                {
+                  "key": "run_id",
+                  "value": "2668"
+                }
+              ]
+            },
+            "description": "Get a TTS evaluation run by ID, optionally with its synthesis results.\n\nUse this endpoint to **poll** an in-flight run and to fetch generated audio URLs once `status == completed`.\n\n**Polling guidance:** Evaluation runs are processed asynchronously by a background worker. Poll this endpoint every 30–60 seconds until `status` is `completed` or `failed`. Do not poll faster than once per 5 seconds.\n\n**Status lifecycle:** `pending` → `processing` → `completed` | `failed`.\n\n**Path parameter**\n- `run_id` (integer, required)\n\n**Query parameters**\n- `include_results` (optional, default `true`)\n- `include_signed_url` (optional, default `false`) — add 1-hour signed URLs for each result's generated WAV file\n\n**Reading a failed run**\nWhen `status == failed`, read the run's top-level `error_message`. Individual result-level failures are reported on each `TTSResult` object's `error_message` field.\n\n**Errors**\n- `404` — Run not found in this org/project\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/tts/runs/:run_id?include_results=true&include_signed_url=false",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "tts",
+                    "runs",
+                    ":run_id"
+                  ],
+                  "query": [
+                    {
+                      "description": "Include results in response",
+                      "key": "include_results",
+                      "value": "true"
+                    },
+                    {
+                      "description": "Include signed URLs for generated audio files",
+                      "key": "include_signed_url",
+                      "value": "false"
+                    }
+                  ],
+                  "variable": [
+                    {
+                      "key": "run_id",
+                      "value": "2668"
+                    }
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": false,\n  \"data\": {\n    \"id\": 2427,\n    \"run_name\": \"string\",\n    \"dataset_name\": \"string\",\n    \"type\": \"string\",\n    \"language_id\": null,\n    \"models\": [\n      \"string\",\n      \"string\"\n    ],\n    \"dataset_id\": 214,\n    \"status\": \"string\",\n    \"total_items\": 6041,\n    \"score\": null,\n    \"error_message\": \"string\",\n    \"organization_id\": 8616,\n    \"project_id\": 6684,\n    \"inserted_at\": \"1961-03-11T04:21:29.751Z\",\n    \"updated_at\": \"2001-12-01T15:11:49.769Z\",\n    \"results\": [\n      {\n        \"id\": 4773,\n        \"sample_text\": \"string\",\n        \"object_store_url\": \"string\",\n        \"provider\": \"string\",\n        \"status\": \"string\",\n        \"score\": null,\n        \"is_correct\": null,\n        \"comment\": null,\n        \"error_message\": null,\n        \"evaluation_run_id\": 3889,\n        \"organization_id\": 4301,\n        \"project_id\": 9719,\n        \"inserted_at\": \"1969-09-13T17:15:36.637Z\",\n        \"updated_at\": \"2017-09-25T16:17:18.134Z\",\n        \"signed_url\": null,\n        \"duration_seconds\": null,\n        \"size_bytes\": 8748\n      },\n      {\n        \"id\": 7586,\n        \"sample_text\": \"string\",\n        \"object_store_url\": \"string\",\n        \"provider\": \"string\",\n        \"status\": \"string\",\n        \"score\": null,\n        \"is_correct\": null,\n        \"comment\": \"string\",\n        \"error_message\": null,\n        \"evaluation_run_id\": 9159,\n        \"organization_id\": 1533,\n        \"project_id\": 9337,\n        \"inserted_at\": \"1989-09-06T17:50:36.517Z\",\n        \"updated_at\": \"1987-03-02T20:05:27.823Z\",\n        \"signed_url\": null,\n        \"duration_seconds\": null,\n        \"size_bytes\": 4636\n      }\n    ],\n    \"run_metadata\": {\n      \"key_0\": false,\n      \"key_1\": \"string\"\n    },\n    \"results_total\": 0\n  },\n  \"error\": \"string\",\n  \"errors\": [\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    },\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    }\n  ],\n  \"metadata\": null\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/tts/runs/:run_id?include_results=true&include_signed_url=false",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "tts",
+                    "runs",
+                    ":run_id"
+                  ],
+                  "query": [
+                    {
+                      "description": "Include results in response",
+                      "key": "include_results",
+                      "value": "true"
+                    },
+                    {
+                      "description": "Include signed URLs for generated audio files",
+                      "key": "include_signed_url",
+                      "value": "false"
+                    }
+                  ],
+                  "variable": [
+                    {
+                      "key": "run_id",
+                      "value": "2668"
+                    }
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        \"string\"\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        5494\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        },
+        {
+          "name": "Update human feedback",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"is_correct\": null,\n  \"comment\": \"string\",\n  \"score\": null\n}",
+              "options": {
+                "raw": {
+                  "headerFamily": "json",
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/tts/results/:result_id",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "tts",
+                "results",
+                ":result_id"
+              ],
+              "variable": [
+                {
+                  "key": "result_id",
+                  "value": "9127"
+                }
+              ]
+            },
+            "description": "Update human feedback and score on a single TTS synthesis result.\n\n**⚠️ Important:** Feedback is **only accepted when the result `status` is `SUCCESS`**. Calling this endpoint on a `PENDING` or `FAILED` result returns `400` with the message: `Cannot provide feedback on result with status '<X>'. Only completed results accept feedback.`\n\nOnly provided fields are updated. Sending a field as `null` clears its value; omitting a field leaves it unchanged.\n\n**Path parameter**\n- `result_id` (integer, required)\n\n**Request body**\n- `is_correct` (boolean | null, optional) — overall audio quality acceptable?\n- `comment` (string | null, optional)\n- `score` (object | null, optional) — free-form metrics. The schema below is **illustrative**, not enforced; you may choose your own keys and values.\n\n**Example**\n```json\n{\n  \"is_correct\": true,\n  \"comment\": \"clear and natural\",\n  \"score\": {\n    \"Speech Naturalness\": \"high\",\n    \"Pronunciation Accuracy\": \"high\",\n    \"Emotion Match\": \"medium\"\n  }\n}\n```\n\n**Suggested score keys** (low | medium | high): `Speech Naturalness`, `Pronunciation Accuracy`, `Emotion Match`, `Speed Appropriateness`.\n\n**Errors specific to this endpoint**\n- `404` — Result not found in this org/project\n- `400` — Result status is not `SUCCESS` (see warning above)\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "PATCH",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"is_correct\": null,\n  \"comment\": \"string\",\n  \"score\": null\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/tts/results/:result_id",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "tts",
+                    "results",
+                    ":result_id"
+                  ],
+                  "variable": [
+                    {
+                      "key": "result_id",
+                      "value": "9127"
+                    }
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": false,\n  \"data\": {\n    \"id\": 8953,\n    \"sample_text\": \"string\",\n    \"object_store_url\": null,\n    \"provider\": \"string\",\n    \"status\": \"string\",\n    \"score\": null,\n    \"is_correct\": null,\n    \"comment\": \"string\",\n    \"error_message\": null,\n    \"evaluation_run_id\": 5932,\n    \"organization_id\": 2636,\n    \"project_id\": 6676,\n    \"inserted_at\": \"1951-05-09T18:16:57.461Z\",\n    \"updated_at\": \"1947-02-28T09:13:16.081Z\",\n    \"signed_url\": null,\n    \"duration_seconds\": 4051.536105708464,\n    \"size_bytes\": null\n  },\n  \"error\": \"string\",\n  \"errors\": [\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    },\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    }\n  ],\n  \"metadata\": {\n    \"key_0\": 7876,\n    \"key_1\": 3642,\n    \"key_2\": 6033.581442702558\n  }\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "PATCH",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"is_correct\": null,\n  \"comment\": \"string\",\n  \"score\": null\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/tts/results/:result_id",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "tts",
+                    "results",
+                    ":result_id"
+                  ],
+                  "variable": [
+                    {
+                      "key": "result_id",
+                      "value": "9127"
+                    }
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        },
+        {
+          "name": "List TTS evaluation runs",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/tts/runs?dataset_id=8342&status=string&limit=50&offset=0",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "tts",
+                "runs"
+              ],
+              "query": [
+                {
+                  "key": "dataset_id",
+                  "value": "8342",
+                  "description": "Filter by dataset ID"
+                },
+                {
+                  "key": "status",
+                  "value": "string",
+                  "description": "Filter by status"
+                },
+                {
+                  "key": "limit",
+                  "value": "50",
+                  "description": "Maximum results to return"
+                },
+                {
+                  "key": "offset",
+                  "value": "0",
+                  "description": "Number of results to skip"
+                }
+              ]
+            },
+            "description": "List TTS evaluation runs for the current project.\n\nSupports filtering by `dataset_id` and `status`, with pagination via `limit` and `offset`. Each entry includes run ID, name, dataset reference, models, status, total items, and timestamps.\n\n**Query parameters**\n- `dataset_id` (optional, integer) — filter to one dataset\n- `status` (optional, string) — one of `pending`, `processing`, `completed`, `failed`\n- `limit` (optional, integer, 1–100, default `50`)\n- `offset` (optional, integer, ≥0, default `0`)\n\n**Status enum:** `pending` → `processing` → `completed` | `failed`.\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/tts/runs?dataset_id=8342&status=string&limit=50&offset=0",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "tts",
+                    "runs"
+                  ],
+                  "query": [
+                    {
+                      "description": "Filter by dataset ID",
+                      "key": "dataset_id",
+                      "value": "8342"
+                    },
+                    {
+                      "description": "Filter by status",
+                      "key": "status",
+                      "value": "string"
+                    },
+                    {
+                      "description": "Maximum results to return",
+                      "key": "limit",
+                      "value": "50"
+                    },
+                    {
+                      "description": "Number of results to skip",
+                      "key": "offset",
+                      "value": "0"
+                    }
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": true,\n  \"data\": null,\n  \"error\": null,\n  \"errors\": null,\n  \"metadata\": {\n    \"key_0\": false\n  }\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/tts/runs?dataset_id=8342&status=string&limit=50&offset=0",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "tts",
+                    "runs"
+                  ],
+                  "query": [
+                    {
+                      "description": "Filter by dataset ID",
+                      "key": "dataset_id",
+                      "value": "8342"
+                    },
+                    {
+                      "description": "Filter by status",
+                      "key": "status",
+                      "value": "string"
+                    },
+                    {
+                      "description": "Maximum results to return",
+                      "key": "limit",
+                      "value": "50"
+                    },
+                    {
+                      "description": "Number of results to skip",
+                      "key": "offset",
+                      "value": "0"
+                    }
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        },
+        {
+          "name": "Start TTS evaluation",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"run_name\": \"voicebot_qa_2024_q4\",\n  \"dataset_id\": 7653,\n  \"models\": [\"gemini-2.5-pro-preview-tts\"]\n}",
+              "options": {
+                "raw": {
+                  "headerFamily": "json",
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/tts/runs",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "tts",
+                "runs"
+              ]
+            },
+            "description": "Start a TTS evaluation run on an existing TTS dataset.\n\nEach text sample is synthesized to audio by every requested model in parallel via the Gemini Batch API. Generated WAV files are stored for human review.\n\n**Authentication:** All Evaluation endpoints require the `X-API-KEY` header (configured at the collection level via the `{{API_KEY}}` variable). Requests are scoped to the organization and project that own the API key.\n\n**Prerequisites**\n1. Create a TTS dataset via **Create TTS dataset**.\n\n**Request body**\n- `run_name` (string, required, min 1 char)\n- `dataset_id` (integer, required)\n- `models` (array of strings, optional, defaults to `[\"gemini-2.5-pro-preview-tts\"]`) — currently exactly **one** value is supported: `gemini-2.5-pro-preview-tts`\n\n**Example**\n```json\n{\n  \"run_name\": \"voicebot_qa_2024_q4\",\n  \"dataset_id\": 7653,\n  \"models\": [\"gemini-2.5-pro-preview-tts\"]\n}\n```\n\n**Default voice configuration**\n- Voice name: `Kore`\n- Style prompt: `Read in a calm, professional customer service tone`\n\nThese defaults are applied automatically; per-run overrides are not yet supported via the API.\n\n**Supported models (current):** `gemini-2.5-pro-preview-tts`\n\n**Polling guidance:** Evaluation runs are processed asynchronously by a background worker. Poll this endpoint every 30–60 seconds until `status` is `completed` or `failed`. Do not poll faster than once per 5 seconds.\n\n**Status lifecycle:** `pending` → `processing` → `completed` | `failed`.\n\n**Errors specific to this endpoint**\n- `404` — Dataset not found in this org/project\n- `400` — Dataset has no samples\n- `422` — One or more `models` values are not in the supported list\n- `500` — Failed to enqueue the batch submission\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"run_name\": \"string\",\n  \"dataset_id\": 7653,\n  \"models\": [\n    \"string\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/tts/runs",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "tts",
+                    "runs"
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": false,\n  \"data\": null,\n  \"error\": null,\n  \"errors\": null,\n  \"metadata\": {\n    \"key_0\": 1142\n  }\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"run_name\": \"string\",\n  \"dataset_id\": 7653,\n  \"models\": [\n    \"string\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/tts/runs",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "tts",
+                    "runs"
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        },
+        {
+          "name": "List TTS datasets",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/tts/datasets?limit=50&offset=0&include_signed_url=false",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "tts",
+                "datasets"
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "50",
+                  "description": "Maximum results to return"
+                },
+                {
+                  "key": "offset",
+                  "value": "0",
+                  "description": "Number of results to skip"
+                },
+                {
+                  "key": "include_signed_url",
+                  "value": "false",
+                  "description": "Include signed URL for dataset files"
+                }
+              ]
+            },
+            "description": "List all TTS evaluation datasets for the current project.\n\nReturns each dataset with ID, name, type, language, object store URL, sample count, and timestamps.\n\n**Query parameters**\n- `limit` (optional, integer, 1–100, default `50`)\n- `offset` (optional, integer, ≥0, default `0`)\n- `include_signed_url` (optional, default `false`) — add a 1-hour signed URL for the dataset file on each entry\n\n**Response metadata** includes `total`, `limit`, `offset` for pagination.\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/tts/datasets?limit=50&offset=0&include_signed_url=false",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "tts",
+                    "datasets"
+                  ],
+                  "query": [
+                    {
+                      "description": "Maximum results to return",
+                      "key": "limit",
+                      "value": "50"
+                    },
+                    {
+                      "description": "Number of results to skip",
+                      "key": "offset",
+                      "value": "0"
+                    },
+                    {
+                      "description": "Include signed URL for dataset files",
+                      "key": "include_signed_url",
+                      "value": "false"
+                    }
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": true,\n  \"data\": null,\n  \"error\": null,\n  \"errors\": [\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    },\n    {\n      \"field\": \"string\",\n      \"message\": \"string\"\n    }\n  ],\n  \"metadata\": null\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/tts/datasets?limit=50&offset=0&include_signed_url=false",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "tts",
+                    "datasets"
+                  ],
+                  "query": [
+                    {
+                      "description": "Maximum results to return",
+                      "key": "limit",
+                      "value": "50"
+                    },
+                    {
+                      "description": "Number of results to skip",
+                      "key": "offset",
+                      "value": "0"
+                    },
+                    {
+                      "description": "Include signed URL for dataset files",
+                      "key": "include_signed_url",
+                      "value": "false"
+                    }
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        },
+        {
+          "name": "Get TTS dataset",
+          "request": {
+            "auth": {
+              "type": "oauth2",
+              "oauth2": [
+                {
+                  "key": "accessTokenUrl",
+                  "value": "/api/v1/login/access-token",
+                  "type": "string"
+                },
+                {
+                  "key": "grant_type",
+                  "value": "password_credentials",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/tts/datasets/:dataset_id?include_signed_url=false",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "tts",
+                "datasets",
+                ":dataset_id"
+              ],
+              "query": [
+                {
+                  "key": "include_signed_url",
+                  "value": "false",
+                  "description": "Include signed URL for dataset file"
+                }
+              ],
+              "variable": [
+                {
+                  "key": "dataset_id",
+                  "value": "6473"
+                }
+              ]
+            },
+            "description": "Get a TTS evaluation dataset by ID.\n\nReturns dataset metadata and a `sample_count` field in the response metadata.\n\n**Path parameter**\n- `dataset_id` (integer, required)\n\n**Query parameter**\n- `include_signed_url` (optional, default `false`) — adds a signed URL for the dataset file valid for **1 hour**.\n\n**Errors**\n- `404` — Dataset not found in this org/project\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/tts/datasets/:dataset_id?include_signed_url=false",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "tts",
+                    "datasets",
+                    ":dataset_id"
+                  ],
+                  "query": [
+                    {
+                      "description": "Include signed URL for dataset file",
+                      "key": "include_signed_url",
+                      "value": "false"
+                    }
+                  ],
+                  "variable": [
+                    {
+                      "key": "dataset_id",
+                      "value": "6473"
+                    }
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": true,\n  \"data\": {\n    \"id\": 2559,\n    \"name\": \"string\",\n    \"description\": null,\n    \"type\": \"string\",\n    \"language_id\": null,\n    \"object_store_url\": \"string\",\n    \"dataset_metadata\": {\n      \"key_0\": \"string\",\n      \"key_1\": 7075.7915381723005\n    },\n    \"organization_id\": 8599,\n    \"project_id\": 5760,\n    \"inserted_at\": \"1977-07-07T13:41:45.015Z\",\n    \"updated_at\": \"1974-08-01T06:05:28.176Z\",\n    \"signed_url\": null\n  },\n  \"error\": null,\n  \"errors\": null,\n  \"metadata\": {\n    \"key_0\": 2821,\n    \"key_1\": true,\n    \"key_2\": 8,\n    \"key_3\": 9486\n  }\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/tts/datasets/:dataset_id?include_signed_url=false",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "tts",
+                    "datasets",
+                    ":dataset_id"
+                  ],
+                  "query": [
+                    {
+                      "description": "Include signed URL for dataset file",
+                      "key": "include_signed_url",
+                      "value": "false"
+                    }
+                  ],
+                  "variable": [
+                    {
+                      "key": "dataset_id",
+                      "value": "6473"
+                    }
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        },
+        {
+          "name": "Create TTS dataset",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"customer_greetings_v1\",\n  \"description\": \"Greetings for support voicebot\",\n  \"language_id\": 5,\n  \"samples\": [\n    { \"text\": \"Welcome to Project Tech4Dev support. How may I help you today?\" }\n  ]\n}",
+              "options": {
+                "raw": {
+                  "headerFamily": "json",
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://api-staging.kaapi.ai/api/v1/evaluations/tts/datasets",
+              "protocol": "https",
+              "host": [
+                "api-staging",
+                "kaapi",
+                "ai"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "evaluations",
+                "tts",
+                "datasets"
+              ]
+            },
+            "description": "Create a new TTS (Text-to-Speech) evaluation dataset from text samples.\n\nEach sample is a plain-text string the TTS model will synthesize during a run. No file upload is required — texts are stored directly.\n\n**Authentication:** All Evaluation endpoints require the `X-API-KEY` header (configured at the collection level via the `{{API_KEY}}` variable). Requests are scoped to the organization and project that own the API key.\n\n**Prerequisites**\n- (Optional) Find a `language_id` via the `Languages` folder's `List Languages` endpoint.\n\n**Request body**\n- `name` (string, required, 1–255 chars) — unique within org/project\n- `description` (string, optional)\n- `language_id` (integer, optional)\n- `samples` (array, required, min 1) — list of `{text}` objects\n- `samples[].text` (string, required, 1–5000 chars, not whitespace-only)\n\n**Example**\n```json\n{\n  \"name\": \"customer_greetings_v1\",\n  \"description\": \"Greetings for support voicebot\",\n  \"language_id\": 5,\n  \"samples\": [\n    { \"text\": \"Welcome to Project Tech4Dev support. How may I help you today?\" },\n    { \"text\": \"Your request has been received. We will get back to you within 24 hours.\" }\n  ]\n}\n```\n\n**Errors specific to this endpoint**\n- `400` — Dataset name already exists in this org/project\n- `404` — Provided `language_id` does not exist\n- `422` — `samples` is empty, any `text` is empty/whitespace, or `text` exceeds 5000 chars\n\n**Error responses:** See the **Errors & Troubleshooting** item at the top of this collection for the full HTTP error matrix and remediation tips."
+          },
+          "response": [
+            {
+              "name": "Successful Response",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"name\": \"string\",\n  \"samples\": [\n    {\n      \"text\": \"string\"\n    }\n  ],\n  \"description\": \"string\",\n  \"language_id\": null\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/tts/datasets",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "tts",
+                    "datasets"
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"success\": true,\n  \"data\": {\n    \"id\": 2559,\n    \"name\": \"string\",\n    \"description\": null,\n    \"type\": \"string\",\n    \"language_id\": null,\n    \"object_store_url\": \"string\",\n    \"dataset_metadata\": {\n      \"key_0\": \"string\",\n      \"key_1\": 7075.7915381723005\n    },\n    \"organization_id\": 8599,\n    \"project_id\": 5760,\n    \"inserted_at\": \"1977-07-07T13:41:45.015Z\",\n    \"updated_at\": \"1974-08-01T06:05:28.176Z\",\n    \"signed_url\": null\n  },\n  \"error\": null,\n  \"errors\": null,\n  \"metadata\": {\n    \"key_0\": 2821,\n    \"key_1\": true,\n    \"key_2\": 8,\n    \"key_3\": 9486\n  }\n}"
+            },
+            {
+              "name": "Validation Error",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: oauth2",
+                    "key": "Authorization",
+                    "value": "<token>"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"name\": \"string\",\n  \"samples\": [\n    {\n      \"text\": \"string\"\n    }\n  ],\n  \"description\": \"string\",\n  \"language_id\": null\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/v1/evaluations/tts/datasets",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "evaluations",
+                    "tts",
+                    "datasets"
+                  ]
+                }
+              },
+              "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+              "code": 422,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        3471\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    },\n    {\n      \"loc\": [\n        \"string\",\n        857\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\",\n      \"input\": \"\",\n      \"ctx\": {}\n    }\n  ]\n}"
+            }
+          ]
+        }
+      ],
+      "description": "Holds endpoints for evaluating Text-to-Speech (TTS) model outputs. Use these to submit audio generation requests and assess the quality and accuracy of TTS responses."
+    }
+  ],
+  "auth": {
+    "type": "apikey",
+    "apikey": [
+      {
+        "key": "value",
+        "value": "{{API_KEY}}",
+        "type": "string"
+      },
+      {
+        "key": "key",
+        "value": "X-API-KEY",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ]
+}

--- a/docs/postman-evaluation-changelog.md
+++ b/docs/postman-evaluation-changelog.md
@@ -1,0 +1,132 @@
+# Postman Collection — Evaluation Section Changelog
+
+Companion document for the Postman PR that lifts the Evaluation, STT Evaluation, and TTS Evaluation folders to a quality bar where a non-technical NGO operator can run the full lifecycle using only API calls.
+
+**Scope:** Evaluation (text/Langfuse), STT Evaluation, TTS Evaluation.
+**Out of scope:** Model Evaluation (untouched in this PR).
+
+---
+
+## Top-level additions
+
+| Item | Location | Purpose |
+|---|---|---|
+| `Errors & Troubleshooting` | New top-level item (first in the collection) | Global error matrix, common traps, capability gaps, auth note |
+| `Getting Started — Text Evaluation` | New first item inside `Evaluation` folder | End-to-end cURL walkthrough |
+| `Getting Started — STT Evaluation` | New first item inside `STT Evaluation` folder | End-to-end cURL walkthrough |
+| `Getting Started — TTS Evaluation` | New first item inside `TTS Evaluation` folder | End-to-end cURL walkthrough |
+
+---
+
+## Bugs fixed in the JSON itself
+
+| # | Endpoint | Bug (before) | Fix (after) |
+|---|---|---|---|
+| 1 | `Evaluation` → `Get Dataset` | URL path `…/datasets/dataset_id={dataset_id}` (query string mashed into path) | URL path `…/datasets/:dataset_id` with `include_signed_url` moved to query; `dataset_id` declared in `variable` |
+| 2 | `Evaluation` → `Delete Dataset` | Same URL path bug as #1 | Path `…/datasets/:dataset_id`, `dataset_id` declared in `variable`, stale query removed |
+| 3 | `STT Evaluation` → `Upload audio file` | Form-data `file` field had `type: "text"`, `value: "string"` — request would not send as multipart file | `type: "file"`, `src: ""` (Postman shows native file picker) |
+| 4 | `STT Evaluation` → `Start STT evaluation` | Body `"models": ["string"]` → guaranteed 422 | `"models": ["gemini-2.5-pro"]` |
+| 5 | `TTS Evaluation` → `Start TTS evaluation` | Body `"models": ["string"]` → guaranteed 422 | `"models": ["gemini-2.5-pro-preview-tts"]` |
+
+### Bonus polish to request bodies
+
+| Endpoint | Before | After |
+|---|---|---|
+| STT `Create STT dataset` | Generic placeholders (`"name": "string"`, random `language_id: 8609`) | Realistic Hindi call-center example with `language_id: 5` |
+| TTS `Create TTS dataset` | Generic `"text": "string"` | Realistic Project Tech4Dev support greeting |
+| STT `Update STT sample` | `"language_id": null, "ground_truth": "string"` | `"language_id": 5, "ground_truth": "corrected transcription text"` |
+
+---
+
+## Per-endpoint description rewrites
+
+Every endpoint's description was replaced. Below is the **delta** for each — what the user gains compared to the previous text.
+
+### Evaluation folder (7 endpoints)
+
+| Endpoint | Key additions |
+|---|---|
+| `Upload Dataset` | 1 MB max size, MIME whitelist, sample CSV inline, errors table (422 / 413 / 409 / 500), explicit field-by-field schema |
+| `List Dataset` | Pagination params (`limit` 1–100 default 50, `offset` ≥0), response example |
+| `Get Dataset` | Path-param/query-param split, 404 behaviour, signed URL 1-hr TTL |
+| `Delete Dataset` | Cascade behaviour (CSV retained, past runs preserved, Langfuse not auto-deleted), 404 |
+| `Evaluate` | Prereq link to `POST /configs`, full field reference, async lifecycle, errors (404 / 400 / 422 / 500), only-`openai`-provider trap |
+| `List Evaluation Runs` | Pagination defaults, status enum with semantics |
+| `Get Evaluation Run Status` | Already strong — now also documents both `400` query-combination errors, the soft trace-info error on non-completed runs, how to read `error_message` on failure |
+
+### STT Evaluation folder (12 endpoints)
+
+| Endpoint | Key additions |
+|---|---|
+| `Upload audio file` | Supported formats and 200 MB cap (already there) + sample cURL, response example, errors (400 / 500), pointer to next step |
+| `List audio files` | Pagination, response shape, signed URL TTL |
+| `Get audio file by ID` | Path param, query param, 404 |
+| `Create STT dataset` | Languages lookup pointer, prereq, full schema, errors (400 file_ids / 400 dup name / 404 language / 422 empty) |
+| `List STT datasets` | Pagination params with limits, response metadata |
+| `Get STT dataset` | Query params (`include_samples`, `include_signed_url`, sample pagination), 404 |
+| `Update STT sample` | Realistic example payload, null vs omitted semantics, 404 |
+| `Start STT evaluation` | Single-model-supported call-out, errors (404 / 400 / 422 / 500), polling note, status enum |
+| `List STT evaluation runs` | Filters (`dataset_id`, `status`), pagination, status enum |
+| `Get STT evaluation run` | Polling note, all query params with defaults, failure-reading guidance |
+| `Get STT result` | Full response schema, score keys (WER/CER/MER/WIL) explained, status enum, 404 |
+| `Update human feedback` | Idempotency, null-clear semantics, 404 |
+
+### TTS Evaluation folder (8 endpoints)
+
+| Endpoint | Key additions |
+|---|---|
+| `Create TTS dataset` | 5000-char per-sample cap, languages lookup pointer, full JSON example, errors (400 / 404 / 422) |
+| `List TTS datasets` | Pagination, `include_signed_url`, response metadata |
+| `Get TTS dataset` | Path/query params, signed URL TTL, 404 |
+| `Start TTS evaluation` | Default voice (`Kore`), default style prompt, single-model call-out, errors, polling note |
+| `List TTS evaluation runs` | Filters, pagination, status enum |
+| `Get TTS evaluation run` | Polling note, query params, failure-reading guidance |
+| `Get TTS result` | Full response schema with `duration_seconds`/`size_bytes`/audio URLs, signed URL TTL, 404 |
+| `Update human feedback` | **Critical** `status == SUCCESS` requirement (otherwise 400), null semantics, suggested score keys, illustrative-only score schema, 404 |
+
+---
+
+## Silent invariants now explicit somewhere
+
+- 1 MB max CSV upload (text eval)
+- 200 MB max audio (STT)
+- 5000 char max per TTS sample
+- Signed URL TTL = 1 hour
+- Supported STT model: `gemini-2.5-pro` only
+- Supported TTS model: `gemini-2.5-pro-preview-tts` only
+- TTS feedback only on `status == SUCCESS`
+- Dataset-name sanitization rule
+- Run status lifecycle: `pending → processing → completed | failed`
+- Per-result status (STT/TTS): `PENDING`, `SUCCESS`, `FAILED`
+
+## Capability gaps surfaced (in Errors & Troubleshooting + each Getting Started)
+
+- Cancel an in-flight run — not supported
+- Retry a failed run — must POST again
+- DELETE STT/TTS datasets — not supported (text eval has DELETE)
+- Append samples to existing dataset — not supported
+- Rename a dataset — not supported
+- Bulk feedback — not supported
+- CSV/JSON results export — not supported
+- Completion webhook — not supported (poll only)
+
+---
+
+## How to apply this to your Postman fork
+
+1. Open your forked Kaapi API'S collection in Postman Cloud.
+2. **Import** → choose `Kaapi API'S.postman_collection.json` from this PR's branch → **Replace** (scoped to your fork only).
+3. Walk the folders top-to-bottom, comparing the description of each endpoint against the deltas above. Adjust wording where you want a local change.
+4. Verify the 5 bug fixes by sending each affected request as-shipped (no manual body edits required) against `api-staging.kaapi.ai`.
+5. In your fork's menu, **Create pull request** → choose the parent collection → confirm.
+
+## Source-of-truth files I cross-checked while writing the descriptions
+
+- `backend/app/api/routes/evaluations/{evaluation,dataset}.py`
+- `backend/app/api/routes/stt_evaluations/{router,evaluation,dataset,files,result}.py`
+- `backend/app/api/routes/tts_evaluations/{router,evaluation,dataset,result}.py`
+- `backend/app/services/evaluations/{validators,evaluation,dataset}.py`
+- `backend/app/services/stt_evaluations/{audio,dataset,constants}.py`
+- `backend/app/services/tts_evaluations/constants.py`
+- `backend/app/models/{stt_evaluation,tts_evaluation,evaluation}.py`
+- `backend/app/crud/{evaluations,stt_evaluations,tts_evaluations}/*.py`


### PR DESCRIPTION
## Summary

Target issue is #_PLEASE_TYPE_ISSUE_NUMBER_

Bring the **Evaluation**, **STT Evaluation**, and **TTS Evaluation** folders of the Postman collection to a quality bar where a non-technical NGO operator can run the full evaluation lifecycle using only API calls.

This PR also tracks `Kaapi API'S.postman_collection.json` under git for the first time, so future updates can flow through reviewable diffs.

**What changed**

- **5 collection bugs fixed** (would have blocked first-time NGO users):
  - 2 URL path errors on `Evaluation` → `Get Dataset` / `Delete Dataset` (`/datasets/dataset_id={dataset_id}` → `/datasets/:dataset_id`)
  - 2 unusable Start STT/TTS bodies replaced `"models": ["string"]` with the actual supported model values
  - 1 form-data field on `Upload audio file` changed from `type: "text"` to `type: "file"` so multipart upload actually works
- **Every endpoint description rewritten** across the 3 eval folders with: field-by-field schema, example payloads, response examples, error codes (400/404/409/413/422/500) with remediation, prerequisite endpoints, status enums, polling guidance
- **3 new "Getting Started" walkthroughs** (one per domain) with end-to-end cURL chains
- **1 new top-level `Errors & Troubleshooting` reference** with the global error matrix, common traps, capability gaps, and auth note
- **Silent invariants made explicit**: 1 MB CSV cap, 200 MB audio cap, 5000-char TTS sample cap, 1-hour signed URL TTL, single supported model per provider, "TTS feedback only on `status == SUCCESS`"
- **Capability gaps surfaced**: cancel/retry/export/bulk-feedback/dataset-DELETE/webhooks are not yet supported — now stated so users don't burn time looking

**Out of scope**

The `Model Evaluation` folder is intentionally untouched in this PR.

**Companion document**

`docs/postman-evaluation-changelog.md` lists the per-endpoint deltas alongside the import-into-fork instructions, so reviewers can scan changes without scrolling the 6500-line JSON.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test. — **N/A: docs-only change to the Postman JSON; no backend code touched.**
- [x] If you've fixed a bug or added code that is tested and has test cases. — **N/A for the same reason. The 5 bugs are in the Postman collection, validated locally with `jq empty` + structural assertions (folder counts, residual bug-pattern grep).**

## Notes

- Recommended review path: read `docs/postman-evaluation-changelog.md` first, then spot-check 2–3 endpoint descriptions inside the JSON.
- After merge, import the updated `Kaapi API'S.postman_collection.json` into the Postman fork ("Import → Replace" scoped to the fork) and open a Postman PR from the fork to the parent collection.
- Cross-referenced source-of-truth files (routes / services / models / CRUD / constants) are listed at the bottom of the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)