### PR TITLE
Config: remove version id from response body

### DIFF
--- a/backend/app/models/config/version.py
+++ b/backend/app/models/config/version.py
@@ -117,7 +117,6 @@ class ConfigVersionUpdate(SQLModel):
 
 
 class ConfigVersionPublic(ConfigVersionBase):
-    id: UUID = Field(description="Unique id for the configuration version")
     config_id: UUID = Field(description="Id of the parent configuration")
     version: int = Field(nullable=False, description="Version number starting at 1")
     inserted_at: datetime


### PR DESCRIPTION
## Summary

Target issue is #624 

### Notes

* **Refactor**
  * Modified the configuration version response structure by removing the unique identifier field , version ID, while retaining core metadata fields (config ID, version number, and timestamps). Version ID is not used anywhere by any endpoint and keeping it in response body along with config id and version number is just confusing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ProjectTech4DevAI/kaapi-backend/pull/822)
