### PR TITLE
Feat: Enable Sentry CeleryIntegration in worker init

### DIFF
--- a/backend/app/celery/celery_app.py
+++ b/backend/app/celery/celery_app.py
@@ -45,9 +45,12 @@ def _initialize_worker_observability() -> None:
                     level=logging.INFO,
                     sentry_logs_level=logging.INFO,
                 ),
+                CeleryIntegration(
+                    propagate_traces=False,
+                    monitor_beat_tasks=False,
+                ),
             ],
             disabled_integrations=[
-                CeleryIntegration(),
                 SqlalchemyIntegration(),
                 HttpxIntegration(),
             ],


### PR DESCRIPTION
## Summary

Target issue is #831 
Explain the **motivation** for making this change. What existing problem does the pull request solve?

Enable Sentry's `CeleryIntegration` in Celery worker observability init so Celery task errors and performance data flow to Sentry. Previously the integration was explicitly disabled, which suppressed Celery-level instrumentation.

Configured with:
- `propagate_traces=False` — avoid linking unrelated task chains into single traces.
- `monitor_beat_tasks=False` — skip Beat cron monitor checkins (not used).

Removed `CeleryIntegration()` from `disabled_integrations` since it is now active.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated error tracking configuration for asynchronous task processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ProjectTech4DevAI/kaapi-backend/pull/827)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->