### PR TITLE
Notification: Evals Notification for evals completion

### DIFF
--- a/backend/app/alembic/versions/061_create_notification_table.py
+++ b/backend/app/alembic/versions/061_create_notification_table.py
@@ -1,0 +1,169 @@
+"""Create generic notification table
+
+Revision ID: 061
+Revises: 060
+Create Date: 2026-05-14 12:00:00.000000
+
+Adds a generic `notification` table used to record outbound notifications
+across providers (email, push, sms, webhook) and entity types (eval_run,
+project, ...). Each row captures a single delivery attempt to a single
+recipient with a JSON snapshot of the template payload, the delivery
+status, and any failure reason. Existence of rows for
+(entity_type, entity_id, notification_type) acts as the idempotency
+guard preventing duplicate sends for the same event.
+"""
+
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "061"
+down_revision = "060"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "notification",
+        sa.Column(
+            "id",
+            sa.Integer(),
+            nullable=False,
+            comment="Unique identifier for the notification record",
+        ),
+        sa.Column(
+            "notification_type",
+            sa.String(length=64),
+            nullable=False,
+            comment=(
+                "Event triggering the notification, e.g. eval_completed, "
+                "eval_failed, magic_link_login"
+            ),
+        ),
+        sa.Column(
+            "provider",
+            sa.String(length=32),
+            nullable=False,
+            comment="Delivery channel: email, push, sms, webhook",
+        ),
+        sa.Column(
+            "recipient_user_id",
+            sa.Integer(),
+            nullable=False,
+            comment="Reference to the user receiving the notification",
+        ),
+        sa.Column(
+            "entity_type",
+            sa.String(length=64),
+            nullable=False,
+            comment="Polymorphic entity type, e.g. eval_run, project",
+        ),
+        sa.Column(
+            "entity_id",
+            sa.Integer(),
+            nullable=False,
+            comment="Polymorphic entity id (not a hard FK across types)",
+        ),
+        sa.Column(
+            "project_id",
+            sa.Integer(),
+            nullable=True,
+            comment=(
+                "Reference to the project the notification belongs to. "
+                "Null for project-agnostic notifications (e.g. magic_link_login)."
+            ),
+        ),
+        sa.Column(
+            "subject",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=True,
+            comment="Subject line (for email-like providers)",
+        ),
+        sa.Column(
+            "body_template",
+            sa.String(length=128),
+            nullable=True,
+            comment="Template identifier used to render the body, e.g. eval_completion_v1",
+        ),
+        sa.Column(
+            "payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+            comment=(
+                "Snapshot of dynamic values used to render the notification "
+                "(eval name, status, timestamp, result link, etc.)"
+            ),
+        ),
+        sa.Column(
+            "status",
+            sa.String(length=16),
+            nullable=False,
+            server_default="pending",
+            comment="Delivery status: pending, sent, failed, skipped",
+        ),
+        sa.Column(
+            "sent_at",
+            sa.DateTime(),
+            nullable=True,
+            comment="Timestamp when delivery succeeded",
+        ),
+        sa.Column(
+            "failed_reason",
+            sa.Text(),
+            nullable=True,
+            comment="Error message if delivery failed",
+        ),
+        sa.Column(
+            "inserted_at",
+            sa.DateTime(),
+            nullable=False,
+            comment="Timestamp when the record was created",
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            nullable=False,
+            comment="Timestamp when the record was last updated",
+        ),
+        sa.ForeignKeyConstraint(
+            ["recipient_user_id"],
+            ["user.id"],
+            name="fk_notification_recipient_user_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["project.id"],
+            name="fk_notification_project_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "idx_notification_entity",
+        "notification",
+        ["entity_type", "entity_id", "notification_type"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_notification_recipient",
+        "notification",
+        ["recipient_user_id"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_notification_status",
+        "notification",
+        ["status"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index("idx_notification_status", table_name="notification")
+    op.drop_index("idx_notification_recipient", table_name="notification")
+    op.drop_index("idx_notification_entity", table_name="notification")
+    op.drop_table("notification")

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -42,6 +42,7 @@ from app.utils import (
     APIResponse,
     generate_magic_link_email,
     load_description,
+    mask_string,
     send_email,
 )
 
@@ -281,7 +282,7 @@ def request_magic_link(session: SessionDep, body: MagicLinkRequest) -> Any:
     user = get_user_by_email(session=session, email=body.email)
     if not user:
         logger.info(
-            f"[request_magic_link] Magic link requested for non-existent email: {body.email}"
+            f"[request_magic_link] Magic link requested for non-existent email: {mask_string(body.email)}"
         )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -332,7 +333,7 @@ def request_magic_link(session: SessionDep, body: MagicLinkRequest) -> Any:
         session.commit()
         logger.info(
             f"[request_magic_link] Magic link email sent | "
-            f"email: {body.email}, notification_id: {notification.id}"
+            f"email: {mask_string(body.email)}, notification_id: {notification.id}"
         )
     except Exception as e:
         mark_notification_failed(
@@ -341,7 +342,7 @@ def request_magic_link(session: SessionDep, body: MagicLinkRequest) -> Any:
         session.commit()
         logger.error(
             f"[request_magic_link] Failed to send magic link email | "
-            f"email: {body.email}, notification_id: {notification.id}, error: {e}"
+            f"email: {mask_string(body.email)}, notification_id: {notification.id}, error: {e}"
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -10,6 +10,11 @@ from app.api.deps import AuthContextDep, SessionDep
 from app.core.config import settings
 from app.crud import get_user_by_email
 from app.crud.auth import get_user_accessible_projects
+from app.crud.notification import (
+    create_pending_notification,
+    mark_notification_failed,
+    mark_notification_sent,
+)
 from app.crud.organization import validate_organization
 from app.crud.project import validate_project
 from app.models import (
@@ -17,6 +22,9 @@ from app.models import (
     GoogleAuthResponse,
     MagicLinkRequest,
     Message,
+    NotificationEntityType,
+    NotificationProvider,
+    NotificationType,
     SelectProjectRequest,
     Token,
 )
@@ -281,33 +289,58 @@ def request_magic_link(session: SessionDep, body: MagicLinkRequest) -> Any:
 
     token = generate_magic_link_token(email=body.email)
 
-    if settings.emails_enabled:
-        try:
-            email_data = generate_magic_link_email(
-                email_to=body.email,
-                magic_link_token=token,
-            )
-            send_email(
-                email_to=body.email,
-                subject=email_data.subject,
-                html_content=email_data.html_content,
-            )
-            logger.info(
-                f"[request_magic_link] Magic link email sent | email: {body.email}"
-            )
-        except Exception as e:
-            logger.error(
-                f"[request_magic_link] Failed to send magic link email | email: {body.email}, error: {e}"
-            )
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to send login email. Please try again later.",
-            )
-    else:
+    if not settings.emails_enabled:
         logger.warning("[request_magic_link] Email sending is not configured")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Email service is not configured",
+        )
+
+    email_data = generate_magic_link_email(
+        email_to=body.email,
+        magic_link_token=token,
+    )
+    notification = create_pending_notification(
+        session=session,
+        notification_type=NotificationType.MAGIC_LINK_LOGIN.value,
+        provider=NotificationProvider.EMAIL.value,
+        recipient_user_id=user.id,
+        entity_type=NotificationEntityType.USER.value,
+        entity_id=user.id,
+        subject=email_data.subject,
+        body_template="magic_link_login_v1",
+        payload={
+            "email": body.email,
+            "valid_minutes": settings.MAGIC_LINK_TOKEN_EXPIRE_MINUTES,
+        },
+    )
+    session.commit()
+    session.refresh(notification)
+
+    try:
+        send_email(
+            email_to=body.email,
+            subject=email_data.subject,
+            html_content=email_data.html_content,
+        )
+        mark_notification_sent(session=session, notification=notification)
+        session.commit()
+        logger.info(
+            f"[request_magic_link] Magic link email sent | "
+            f"email: {body.email}, notification_id: {notification.id}"
+        )
+    except Exception as e:
+        mark_notification_failed(
+            session=session, notification=notification, reason=str(e)
+        )
+        session.commit()
+        logger.error(
+            f"[request_magic_link] Failed to send magic link email | "
+            f"email: {body.email}, notification_id: {notification.id}, error: {e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to send login email. Please try again later.",
         )
 
     return APIResponse.success_response(

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -17,6 +17,7 @@ from app.crud.notification import (
 )
 from app.crud.organization import validate_organization
 from app.crud.project import validate_project
+from app.crud.user_project import get_user_projects
 from app.models import (
     GoogleAuthRequest,
     GoogleAuthResponse,
@@ -300,6 +301,9 @@ def request_magic_link(session: SessionDep, body: MagicLinkRequest) -> Any:
         email_to=body.email,
         magic_link_token=token,
     )
+    user_project_link = next(
+        iter(get_user_projects(session=session, user_id=user.id)), None
+    )
     notification = create_pending_notification(
         session=session,
         notification_type=NotificationType.MAGIC_LINK_LOGIN.value,
@@ -307,6 +311,7 @@ def request_magic_link(session: SessionDep, body: MagicLinkRequest) -> Any:
         recipient_user_id=user.id,
         entity_type=NotificationEntityType.USER.value,
         entity_id=user.id,
+        project_id=user_project_link.project_id if user_project_link else None,
         subject=email_data.subject,
         body_template="magic_link_login_v1",
         payload={

--- a/backend/app/api/routes/user_project.py
+++ b/backend/app/api/routes/user_project.py
@@ -32,6 +32,7 @@ from app.utils import (
     APIResponse,
     generate_invite_email,
     load_description,
+    mask_string,
     send_email,
 )
 
@@ -115,7 +116,7 @@ def add_project_users(
             invited_user = get_user_by_email(session=session, email=email_str)
             if not invited_user:
                 logger.error(
-                    f"[add_project_users] Inviting user row missing after add | email: {email_str}"
+                    f"[add_project_users] Inviting user row missing after add | email: {mask_string(email_str)}"
                 )
                 continue
 
@@ -160,7 +161,7 @@ def add_project_users(
                 session.commit()
                 logger.info(
                     f"[add_project_users] Invitation email sent | "
-                    f"email: {entry.email}, notification_id: {notification.id}"
+                    f"email: {mask_string(email_str)}, notification_id: {notification.id}"
                 )
             except Exception as e:
                 mark_notification_failed(
@@ -169,7 +170,7 @@ def add_project_users(
                 session.commit()
                 logger.error(
                     f"[add_project_users] Failed to send invitation email | "
-                    f"email: {entry.email}, notification_id: {notification.id}, error: {e}"
+                    f"email: {mask_string(email_str)}, notification_id: {notification.id}, error: {e}"
                 )
 
     # Re-fetch all users for this project to return the full list

--- a/backend/app/api/routes/user_project.py
+++ b/backend/app/api/routes/user_project.py
@@ -6,6 +6,12 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from app.api.deps import AuthContextDep, SessionDep
 from app.api.permissions import Permission, require_permission
 from app.core.config import settings
+from app.crud import get_user_by_email
+from app.crud.notification import (
+    create_pending_notification,
+    mark_notification_failed,
+    mark_notification_sent,
+)
 from app.crud.organization import get_organization_by_id, validate_organization
 from app.crud.project import get_project_by_id, validate_project
 from app.crud.user_project import (
@@ -16,6 +22,9 @@ from app.crud.user_project import (
 from app.models import (
     AddUsersToProjectRequest,
     Message,
+    NotificationEntityType,
+    NotificationProvider,
+    NotificationType,
     UserProjectPublic,
 )
 from app.services.auth import generate_invite_token
@@ -102,29 +111,65 @@ def add_project_users(
 
     if settings.emails_enabled and organization and project:
         for entry in body.users:
+            email_str = str(entry.email)
+            invited_user = get_user_by_email(session=session, email=email_str)
+            if not invited_user:
+                logger.error(
+                    f"[add_project_users] Inviting user row missing after add | email: {email_str}"
+                )
+                continue
+
+            invite_token = generate_invite_token(
+                email=email_str,
+                organization_id=body.organization_id,
+                project_id=body.project_id,
+            )
+            email_data = generate_invite_email(
+                email_to=email_str,
+                project_name=project.name,
+                organization_name=organization.name,
+                invite_token=invite_token,
+            )
+            notification = create_pending_notification(
+                session=session,
+                notification_type=NotificationType.INVITE_USER.value,
+                provider=NotificationProvider.EMAIL.value,
+                recipient_user_id=invited_user.id,
+                entity_type=NotificationEntityType.USER.value,
+                entity_id=invited_user.id,
+                project_id=body.project_id,
+                subject=email_data.subject,
+                body_template="invite_user_v1",
+                payload={
+                    "email": email_str,
+                    "project_name": project.name,
+                    "organization_name": organization.name,
+                    "valid_days": settings.INVITE_TOKEN_EXPIRE_HOURS // 24,
+                },
+            )
+            session.commit()
+            session.refresh(notification)
+
             try:
-                invite_token = generate_invite_token(
-                    email=str(entry.email),
-                    organization_id=body.organization_id,
-                    project_id=body.project_id,
-                )
-                email_data = generate_invite_email(
-                    email_to=str(entry.email),
-                    project_name=project.name,
-                    organization_name=organization.name,
-                    invite_token=invite_token,
-                )
                 send_email(
-                    email_to=str(entry.email),
+                    email_to=email_str,
                     subject=email_data.subject,
                     html_content=email_data.html_content,
                 )
+                mark_notification_sent(session=session, notification=notification)
+                session.commit()
                 logger.info(
-                    f"[add_project_users] Invitation email sent | email: {entry.email}"
+                    f"[add_project_users] Invitation email sent | "
+                    f"email: {entry.email}, notification_id: {notification.id}"
                 )
             except Exception as e:
+                mark_notification_failed(
+                    session=session, notification=notification, reason=str(e)
+                )
+                session.commit()
                 logger.error(
-                    f"[add_project_users] Failed to send invitation email | email: {entry.email}, error: {e}"
+                    f"[add_project_users] Failed to send invitation email | "
+                    f"email: {entry.email}, notification_id: {notification.id}, error: {e}"
                 )
 
     # Re-fetch all users for this project to return the full list

--- a/backend/app/celery/celery_app.py
+++ b/backend/app/celery/celery_app.py
@@ -163,6 +163,7 @@ celery_app = Celery(
     backend=settings.REDIS_URL,
     include=[
         "app.celery.tasks.job_execution",
+        "app.celery.tasks.notifications",
     ],
 )
 

--- a/backend/app/celery/tasks/notifications.py
+++ b/backend/app/celery/tasks/notifications.py
@@ -1,0 +1,230 @@
+import logging
+
+from sqlmodel import Session
+
+from app.celery.celery_app import celery_app
+from app.celery.utils import gevent_timeout
+from app.core.config import settings
+from app.core.db import engine
+from app.crud.notification import (
+    create_pending_notification,
+    list_pending_notifications_for_entity,
+    mark_notification_failed,
+    mark_notification_sent,
+    notifications_exist_for_entity,
+)
+from app.crud.user_project import get_users_by_project
+from app.models import (
+    EvaluationRun,
+    NotificationEntityType,
+    NotificationProvider,
+    NotificationType,
+    Project,
+)
+from app.utils import generate_eval_completion_email, send_email
+
+logger = logging.getLogger(__name__)
+
+EVAL_COMPLETION_TEMPLATE = "eval_completion_v1"
+
+
+def _build_eval_results_link(eval_run: EvaluationRun) -> str:
+    return (
+        f"{settings.FRONTEND_HOST}/projects/{eval_run.project_id}"
+        f"/evaluations/{eval_run.id}"
+    )
+
+
+def _notification_type_for_status(status: str) -> str:
+    if status == "failed":
+        return NotificationType.EVAL_FAILED.value
+    return NotificationType.EVAL_COMPLETED.value
+
+
+def _build_eval_completion_payload(
+    *, eval_run: EvaluationRun, project_name: str
+) -> dict:
+    completed_at = eval_run.updated_at.isoformat() if eval_run.updated_at else None
+    return {
+        "run_name": eval_run.run_name,
+        "project_name": project_name,
+        "status": eval_run.status,
+        "completed_at": completed_at,
+        "link": _build_eval_results_link(eval_run),
+        "error_message": eval_run.error_message,
+    }
+
+
+@celery_app.task(bind=True, queue="low_priority", priority=1)
+@gevent_timeout(
+    settings.CELERY_TASK_SOFT_TIME_LIMIT, "send_eval_completion_notification"
+)
+def send_eval_completion_notification(self, evaluation_id: int) -> dict:
+    """
+    Fan out a completion notification for an eval run to every project member.
+
+    The flow per recipient is: insert a `pending` notification row with the
+    payload snapshot, attempt SMTP delivery, then flip the row to `sent`
+    (with `sent_at`) or `failed` (with `failed_reason`). The `notification`
+    table itself acts as the idempotency guard — if any rows already exist
+    for this (entity_type, entity_id, notification_type), the task bails
+    out without sending again.
+    """
+    with Session(engine) as session:
+        eval_run = session.get(EvaluationRun, evaluation_id)
+        if not eval_run:
+            logger.error(
+                f"[send_eval_completion_notification] EvaluationRun not found | "
+                f"evaluation_id={evaluation_id}"
+            )
+            return {
+                "evaluation_id": evaluation_id,
+                "sent": 0,
+                "failed": 0,
+                "not_found": True,
+            }
+
+        notification_type = _notification_type_for_status(eval_run.status)
+
+        already_processed = notifications_exist_for_entity(
+            session=session,
+            entity_type=NotificationEntityType.EVAL_RUN.value,
+            entity_id=eval_run.id,
+            notification_type=notification_type,
+        )
+        if already_processed:
+            logger.info(
+                f"[send_eval_completion_notification] Already processed; skipping | "
+                f"evaluation_id={evaluation_id} | type={notification_type}"
+            )
+            return {
+                "evaluation_id": evaluation_id,
+                "sent": 0,
+                "failed": 0,
+                "skipped": True,
+            }
+
+        if not settings.emails_enabled:
+            logger.warning(
+                f"[send_eval_completion_notification] Email not configured; skipping | "
+                f"evaluation_id={evaluation_id}"
+            )
+            return {
+                "evaluation_id": evaluation_id,
+                "sent": 0,
+                "failed": 0,
+                "skipped": True,
+            }
+
+        project = session.get(Project, eval_run.project_id)
+        project_name = project.name if project else f"Project {eval_run.project_id}"
+
+        users = get_users_by_project(session=session, project_id=eval_run.project_id)
+        recipients = [u for u in users if u.is_active and u.email]
+        if not recipients:
+            logger.info(
+                f"[send_eval_completion_notification] No recipients for project | "
+                f"evaluation_id={evaluation_id} | project_id={eval_run.project_id}"
+            )
+            return {"evaluation_id": evaluation_id, "sent": 0, "failed": 0}
+
+        payload = _build_eval_completion_payload(
+            eval_run=eval_run, project_name=project_name
+        )
+        email_data = generate_eval_completion_email(
+            run_name=eval_run.run_name,
+            project_name=project_name,
+            status=eval_run.status,
+            completed_at=(
+                eval_run.updated_at.strftime("%Y-%m-%d %H:%M:%S UTC")
+                if eval_run.updated_at
+                else ""
+            ),
+            link=payload["link"],
+            error_message=eval_run.error_message,
+        )
+
+        seen_user_ids: set[int] = set()
+        for user in recipients:
+            if user.user_id in seen_user_ids:
+                continue
+            seen_user_ids.add(user.user_id)
+            create_pending_notification(
+                session=session,
+                notification_type=notification_type,
+                provider=NotificationProvider.EMAIL.value,
+                recipient_user_id=user.user_id,
+                entity_type=NotificationEntityType.EVAL_RUN.value,
+                entity_id=eval_run.id,
+                project_id=eval_run.project_id,
+                subject=email_data.subject,
+                body_template=EVAL_COMPLETION_TEMPLATE,
+                payload=payload,
+            )
+        session.commit()
+
+        pending = list_pending_notifications_for_entity(
+            session=session,
+            entity_type=NotificationEntityType.EVAL_RUN.value,
+            entity_id=eval_run.id,
+            notification_type=notification_type,
+        )
+
+        sent_count = 0
+        failed_count = 0
+        for notification in pending:
+            email_to = next(
+                (
+                    u.email
+                    for u in recipients
+                    if u.user_id == notification.recipient_user_id
+                ),
+                None,
+            )
+            if not email_to:
+                mark_notification_failed(
+                    session=session,
+                    notification=notification,
+                    reason="Recipient email not available",
+                )
+                failed_count += 1
+                continue
+            try:
+                send_email(
+                    email_to=email_to,
+                    subject=email_data.subject,
+                    html_content=email_data.html_content,
+                )
+                mark_notification_sent(session=session, notification=notification)
+                sent_count += 1
+                logger.info(
+                    f"[send_eval_completion_notification] Sent | "
+                    f"evaluation_id={evaluation_id} | "
+                    f"notification_id={notification.id} | to={email_to}"
+                )
+            except Exception as e:
+                mark_notification_failed(
+                    session=session, notification=notification, reason=str(e)
+                )
+                failed_count += 1
+                logger.error(
+                    f"[send_eval_completion_notification] Send failed | "
+                    f"evaluation_id={evaluation_id} | "
+                    f"notification_id={notification.id} | to={email_to} | error={e}",
+                    exc_info=True,
+                )
+        session.commit()
+
+        logger.info(
+            f"[send_eval_completion_notification] Done | "
+            f"evaluation_id={evaluation_id} | project_id={eval_run.project_id} | "
+            f"type={notification_type} | recipients={len(pending)} | "
+            f"sent={sent_count} | failed={failed_count}"
+        )
+        return {
+            "evaluation_id": evaluation_id,
+            "notification_type": notification_type,
+            "recipients": len(pending),
+            "sent": sent_count,
+            "failed": failed_count,
+        }

--- a/backend/app/celery/tasks/notifications.py
+++ b/backend/app/celery/tasks/notifications.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 
 from sqlmodel import Session
 
@@ -38,15 +39,21 @@ def _notification_type_for_status(status: str) -> str:
     return NotificationType.EVAL_COMPLETED.value
 
 
+def _format_completed_at(dt: datetime | None) -> str:
+    if not dt:
+        return ""
+    hour_12 = dt.strftime("%I").lstrip("0") or "12"
+    return dt.strftime(f"%B %d, %Y at {hour_12}:%M %p")
+
+
 def _build_eval_completion_payload(
     *, eval_run: EvaluationRun, project_name: str
 ) -> dict:
-    completed_at = eval_run.updated_at.isoformat() if eval_run.updated_at else None
     return {
         "run_name": eval_run.run_name,
         "project_name": project_name,
         "status": eval_run.status,
-        "completed_at": completed_at,
+        "completed_at": _format_completed_at(eval_run.updated_at),
         "link": _build_eval_results_link(eval_run),
         "error_message": eval_run.error_message,
     }
@@ -132,11 +139,7 @@ def send_eval_completion_notification(self, evaluation_id: int) -> dict:
             run_name=eval_run.run_name,
             project_name=project_name,
             status=eval_run.status,
-            completed_at=(
-                eval_run.updated_at.strftime("%B %d, %Y at %-I:%M %p")
-                if eval_run.updated_at
-                else ""
-            ),
+            completed_at=payload["completed_at"],
             link=payload["link"],
             error_message=eval_run.error_message,
         )

--- a/backend/app/celery/tasks/notifications.py
+++ b/backend/app/celery/tasks/notifications.py
@@ -29,10 +29,7 @@ EVAL_COMPLETION_TEMPLATE = "eval_completion_v1"
 
 
 def _build_eval_results_link(eval_run: EvaluationRun) -> str:
-    return (
-        f"{settings.FRONTEND_HOST}/projects/{eval_run.project_id}"
-        f"/evaluations/{eval_run.id}"
-    )
+    return f"{settings.FRONTEND_HOST}/evaluations/{eval_run.id}"
 
 
 def _notification_type_for_status(status: str) -> str:
@@ -136,7 +133,7 @@ def send_eval_completion_notification(self, evaluation_id: int) -> dict:
             project_name=project_name,
             status=eval_run.status,
             completed_at=(
-                eval_run.updated_at.strftime("%Y-%m-%d %H:%M:%S UTC")
+                eval_run.updated_at.strftime("%B %d, %Y at %-I:%M %p")
                 if eval_run.updated_at
                 else ""
             ),

--- a/backend/app/celery/tasks/notifications.py
+++ b/backend/app/celery/tasks/notifications.py
@@ -1,5 +1,6 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 from sqlmodel import Session
 
@@ -27,6 +28,7 @@ from app.utils import generate_eval_completion_email, send_email
 logger = logging.getLogger(__name__)
 
 EVAL_COMPLETION_TEMPLATE = "eval_completion_v1"
+IST_TZ = ZoneInfo("Asia/Kolkata")
 
 
 def _build_eval_results_link(eval_run: EvaluationRun) -> str:
@@ -42,8 +44,11 @@ def _notification_type_for_status(status: str) -> str:
 def _format_completed_at(dt: datetime | None) -> str:
     if not dt:
         return ""
-    hour_12 = dt.strftime("%I").lstrip("0") or "12"
-    return dt.strftime(f"%B %d, %Y at {hour_12}:%M %p")
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    local = dt.astimezone(IST_TZ)
+    hour_12 = local.strftime("%I").lstrip("0") or "12"
+    return local.strftime(f"%B %d, %Y at {hour_12}:%M %p")
 
 
 def _build_eval_completion_payload(

--- a/backend/app/crud/evaluations/core.py
+++ b/backend/app/crud/evaluations/core.py
@@ -191,6 +191,9 @@ def get_evaluation_run_by_id(
     return eval_run
 
 
+TERMINAL_EVAL_STATUSES = {"completed", "failed"}
+
+
 def update_evaluation_run(
     session: Session,
     eval_run: EvaluationRun,
@@ -202,8 +205,22 @@ def update_evaluation_run(
     Only fields explicitly set on `update` are applied (`exclude_unset=True`
     semantics), so callers don't accidentally clear unrelated columns.
     `updated_at` is always bumped.
+
+    When the update transitions the run into a terminal status (`completed`
+    or `failed`) for the first time, enqueues a Celery task to send
+    completion notifications. The downstream task re-checks the
+    `notification` table for existing rows so a duplicate enqueue is a
+    no-op rather than a duplicate send.
     """
-    for field_name, new_value in update.model_dump(exclude_unset=True).items():
+    update_fields = update.model_dump(exclude_unset=True)
+    incoming_status = update_fields.get("status")
+    previous_status = eval_run.status
+    should_notify = (
+        incoming_status in TERMINAL_EVAL_STATUSES
+        and previous_status not in TERMINAL_EVAL_STATUSES
+    )
+
+    for field_name, new_value in update_fields.items():
         setattr(eval_run, field_name, new_value)
 
     eval_run.updated_at = now()
@@ -218,7 +235,33 @@ def update_evaluation_run(
         logger.error(f"Failed to update EvaluationRun: {e}", exc_info=True)
         raise
 
+    if should_notify:
+        _enqueue_eval_completion_notification(eval_run)
+
     return eval_run
+
+
+def _enqueue_eval_completion_notification(eval_run: EvaluationRun) -> None:
+    """Enqueue the completion email task, swallowing broker errors.
+
+    Imported lazily to avoid a circular import: the celery task module
+    pulls in CRUD helpers via `app.crud.user_project`, which would loop
+    back through `app.crud` package init.
+    """
+    try:
+        from app.celery.tasks.notifications import send_eval_completion_notification
+
+        send_eval_completion_notification.delay(eval_run.id)
+        logger.info(
+            f"[update_evaluation_run] Enqueued completion notification | "
+            f"evaluation_id={eval_run.id} | status={eval_run.status}"
+        )
+    except Exception as e:
+        logger.error(
+            f"[update_evaluation_run] Failed to enqueue completion notification | "
+            f"evaluation_id={eval_run.id} | error={e}",
+            exc_info=True,
+        )
 
 
 def get_or_fetch_score(

--- a/backend/app/crud/notification.py
+++ b/backend/app/crud/notification.py
@@ -1,0 +1,92 @@
+import logging
+from typing import Any
+
+from sqlmodel import Session, select
+
+from app.core.util import now
+from app.models import Notification, NotificationStatus
+
+logger = logging.getLogger(__name__)
+
+
+def notifications_exist_for_entity(
+    *,
+    session: Session,
+    entity_type: str,
+    entity_id: int,
+    notification_type: str,
+) -> bool:
+    """Return True if any notification has already been recorded for this event.
+
+    Used as the idempotency guard before creating a new fan-out of pending
+    notifications for a terminal eval-run transition.
+    """
+    statement = select(Notification.id).where(
+        Notification.entity_type == entity_type,
+        Notification.entity_id == entity_id,
+        Notification.notification_type == notification_type,
+    )
+    return session.exec(statement).first() is not None
+
+
+def create_pending_notification(
+    *,
+    session: Session,
+    notification_type: str,
+    provider: str,
+    recipient_user_id: int,
+    entity_type: str,
+    entity_id: int,
+    project_id: int | None = None,
+    subject: str | None = None,
+    body_template: str | None = None,
+    payload: dict[str, Any] | None = None,
+) -> Notification:
+    """Insert a pending notification row. Caller commits."""
+    notification = Notification(
+        notification_type=notification_type,
+        provider=provider,
+        recipient_user_id=recipient_user_id,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        project_id=project_id,
+        subject=subject,
+        body_template=body_template,
+        payload=payload or {},
+        status=NotificationStatus.PENDING.value,
+    )
+    session.add(notification)
+    return notification
+
+
+def mark_notification_sent(*, session: Session, notification: Notification) -> None:
+    notification.status = NotificationStatus.SENT.value
+    notification.sent_at = now()
+    notification.failed_reason = None
+    notification.updated_at = now()
+    session.add(notification)
+
+
+def mark_notification_failed(
+    *, session: Session, notification: Notification, reason: str
+) -> None:
+    notification.status = NotificationStatus.FAILED.value
+    notification.failed_reason = reason[:2000] if reason else "Unknown error"
+    notification.updated_at = now()
+    session.add(notification)
+
+
+def list_pending_notifications_for_entity(
+    *,
+    session: Session,
+    entity_type: str,
+    entity_id: int,
+    notification_type: str,
+) -> list[Notification]:
+    statement = select(Notification).where(
+        Notification.entity_type == entity_type,
+        Notification.entity_id == entity_id,
+        Notification.notification_type == notification_type,
+        Notification.status == NotificationStatus.PENDING.value,
+    )
+    return list(session.exec(statement).all())

--- a/backend/app/email-templates/build/eval_completion.html
+++ b/backend/app/email-templates/build/eval_completion.html
@@ -11,7 +11,7 @@
   <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
     <tr>
       <td align="center" style="padding: 48px 16px;">
-        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width: 520px; background-color: #ffffff; border: 1px solid #e5e7eb; border-radius: 12px;">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width: 520px; background-color: #ffffff; border-radius: 12px;">
 
           <tr>
             <td style="padding: 32px 40px 8px;">

--- a/backend/app/email-templates/build/eval_completion.html
+++ b/backend/app/email-templates/build/eval_completion.html
@@ -1,95 +1,152 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="color-scheme" content="light only">
-  <meta name="supported-color-schemes" content="light only">
-  <title>{{ app_name }} - Evaluation {{ status_label }}</title>
-</head>
-<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background-color: #f6f7f9; color: #1f2937;">
-  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
-    <tr>
-      <td align="center" style="padding: 48px 16px;">
-        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width: 520px; background-color: #ffffff; border-radius: 12px;">
-
-          <tr>
-            <td style="padding: 32px 40px 8px;">
-              <p style="margin: 0; font-size: 14px; font-weight: 600; color: #1f4496; letter-spacing: 0.2px; text-align: center;">
-                {{ app_name }}
-              </p>
-            </td>
-          </tr>
-
-          <tr>
-            <td style="padding: 16px 40px 8px;">
-              <h1 style="margin: 0 0 12px; font-size: 22px; font-weight: 600; color: #111827; line-height: 1.35;">
-                Evaluation {{ status_label|lower }}
-              </h1>
-              <p style="margin: 0; font-size: 15px; line-height: 1.6; color: #4b5563;">
-                Your evaluation run <strong style="color: #111827; font-weight: 600;">{{ run_name }}</strong> in <strong style="color: #111827; font-weight: 600;">{{ project_name }}</strong> has finished.
-              </p>
-            </td>
-          </tr>
-
-          <tr>
-            <td style="padding: 24px 40px 8px;">
-              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="border-top: 1px solid #e5e7eb;">
-                <tr>
-                  <td style="padding: 14px 0; font-size: 13px; color: #6b7280; width: 120px;">Evaluation</td>
-                  <td style="padding: 14px 0; font-size: 13px; color: #111827; font-weight: 500;">{{ run_name }}</td>
-                </tr>
-                <tr>
-                  <td style="padding: 14px 0; font-size: 13px; color: #6b7280; border-top: 1px solid #f3f4f6;">Project</td>
-                  <td style="padding: 14px 0; font-size: 13px; color: #111827; font-weight: 500; border-top: 1px solid #f3f4f6;">{{ project_name }}</td>
-                </tr>
-                <tr>
-                  <td style="padding: 14px 0; font-size: 13px; color: #6b7280; border-top: 1px solid #f3f4f6;">Status</td>
-                  <td style="padding: 14px 0; font-size: 13px; color: #111827; font-weight: 500; border-top: 1px solid #f3f4f6;">{{ status_label }}</td>
-                </tr>
-                <tr>
-                  <td style="padding: 14px 0; font-size: 13px; color: #6b7280; border-top: 1px solid #f3f4f6;">Completed</td>
-                  <td style="padding: 14px 0; font-size: 13px; color: #111827; font-weight: 500; border-top: 1px solid #f3f4f6;">{{ completed_at }}</td>
-                </tr>
-              </table>
-            </td>
-          </tr>
-
-          {% if error_message %}
-          <tr>
-            <td style="padding: 8px 40px 0;">
-              <p style="margin: 0; font-size: 13px; line-height: 1.6; color: #b91c1c;">
-                <strong style="font-weight: 600;">Error:</strong> {{ error_message }}
-              </p>
-            </td>
-          </tr>
-          {% endif %}
-
-          <tr>
-            <td align="center" style="padding: 28px 40px 8px;">
-              <table role="presentation" cellspacing="0" cellpadding="0" border="0">
-                <tr>
-                  <td style="background-color: #1f4496; border-radius: 999px;">
-                    <a href="{{ link }}" target="_blank" style="display: inline-block; padding: 12px 36px; font-size: 14px; font-weight: 600; color: #ffffff; text-decoration: none;">
-                      View Results
-                    </a>
-                  </td>
-                </tr>
-              </table>
-            </td>
-          </tr>
-
-          <tr>
-            <td style="padding: 24px 40px 32px;">
-              <p style="margin: 0; font-size: 12px; line-height: 1.6; color: #9ca3af; text-align: center;">
-                You're receiving this because you're a member of {{ project_name }} on {{ app_name }}.
-              </p>
-            </td>
-          </tr>
-
-        </table>
-      </td>
-    </tr>
-  </table>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{ app_name }} - Evaluation {{ status_label }}</title>
+  </head>
+  <body
+    style="
+      margin: 0;
+      padding: 0;
+      font-family:
+        -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto,
+        Helvetica, Arial, sans-serif;
+      background-color: #f4f4f5;
+    "
+  >
+    <table
+      role="presentation"
+      width="100%"
+      cellspacing="0"
+      cellpadding="0"
+      border="0"
+    >
+      <tr>
+        <td style="padding: 60px 20px">
+          <table
+            role="presentation"
+            width="100%"
+            cellspacing="0"
+            cellpadding="0"
+            border="0"
+            style="max-width: 520px; margin: 0 auto"
+          >
+            <tr>
+              <td
+                align="center"
+                style="
+                  background-color: #ffffff;
+                  padding: 48px 40px;
+                  text-align: center;
+                "
+              >
+                <h1
+                  style="
+                    margin: 0 0 4px;
+                    font-size: 22px;
+                    font-weight: 600;
+                    color: #18181b;
+                  "
+                >
+                  {{ app_name }}
+                </h1>
+                <p style="margin: 0 0 20px; font-size: 14px; color: #a1a1aa">
+                  Evaluation {{ status_label|lower }}
+                </p>
+                <table
+                  role="presentation"
+                  width="40"
+                  cellspacing="0"
+                  cellpadding="0"
+                  border="0"
+                  style="margin: 0 auto 20px"
+                >
+                  <tr>
+                    <td style="border-top: 2px solid #e4e4e7"></td>
+                  </tr>
+                </table>
+                <p
+                  style="
+                    margin: 0 0 5px;
+                    font-size: 15px;
+                    line-height: 1.7;
+                    color: #3f3f46;
+                  "
+                >
+                  Your evaluation run
+                  <span style="font-weight: bold">{{ run_name }}</span> in
+                  <span style="font-weight: bold">{{ project_name }}</span> has
+                  <span style="font-weight: bold"
+                    >{{ status_label|lower }}</span
+                  >
+                  on <span style="font-weight: bold">{{ completed_at }}</span>.
+                </p>
+                <p
+                  style="
+                    margin: 0 0 20px;
+                    font-size: 15px;
+                    line-height: 1.7;
+                    color: #3f3f46;
+                  "
+                >
+                  Click the button below to view the results and detailed
+                  traces.
+                </p>
+                {% if error_message %}
+                <p
+                  style="
+                    margin: 0 0 20px;
+                    font-size: 14px;
+                    line-height: 1.6;
+                    color: #b91c1c;
+                  "
+                >
+                  Error: {{ error_message }}
+                </p>
+                {% endif %}
+                <table
+                  role="presentation"
+                  cellspacing="0"
+                  cellpadding="0"
+                  border="0"
+                  style="margin: 0 auto"
+                >
+                  <tr>
+                    <td style="background-color: #1f4496; border-radius: 999px">
+                      <a
+                        href="{{ link }}"
+                        target="_blank"
+                        style="
+                          display: inline-block;
+                          padding: 10px 30px;
+                          font-size: 15px;
+                          font-weight: 600;
+                          color: #ffffff;
+                          text-decoration: none;
+                        "
+                      >
+                        View Results
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+                <p
+                  style="
+                    margin: 20px 0 0;
+                    font-size: 12px;
+                    color: #a1a1aa;
+                    line-height: 1.6;
+                  "
+                >
+                  You're receiving this because you're a member of the {{
+                  project_name }} project on {{ app_name }}.
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
 </html>

--- a/backend/app/email-templates/build/eval_completion.html
+++ b/backend/app/email-templates/build/eval_completion.html
@@ -77,10 +77,16 @@
                   Your evaluation run
                   <span style="font-weight: bold">{{ run_name }}</span> in
                   <span style="font-weight: bold">{{ project_name }}</span> has
-                  <span style="font-weight: bold"
+                  {% if status_label == "Completed" %}
+                  <span style="font-weight: bold; color: #047857"
                     >{{ status_label|lower }}</span
                   >
-                  on <span style="font-weight: bold">{{ completed_at }}</span>.
+                  {% else %}
+                  <span style="font-weight: bold; color: #b91c1c"
+                    >{{ status_label|lower }}</span
+                  >
+                  {% endif %} on
+                  <span style="font-weight: bold">{{ completed_at }}</span>.
                 </p>
                 <p
                   style="

--- a/backend/app/email-templates/build/eval_completion.html
+++ b/backend/app/email-templates/build/eval_completion.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Evaluation {{ status_label }} - {{ run_name }}</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background-color: #f4f4f5;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+    <tr>
+      <td style="padding: 60px 20px;">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width: 560px; margin: 0 auto;">
+          <tr>
+            <td style="background-color: #ffffff; padding: 48px 40px;">
+              <h1 style="margin: 0 0 4px; font-size: 22px; font-weight: 600; color: #18181b; text-align: center;">
+                {{ app_name }}
+              </h1>
+              <p style="margin: 0 0 20px; font-size: 14px; color: #a1a1aa; text-align: center;">
+                {{ project_name }}
+              </p>
+              <table role="presentation" width="40" cellspacing="0" cellpadding="0" border="0" style="margin: 0 auto 20px;">
+                <tr>
+                  <td style="border-top: 2px solid #e4e4e7;"></td>
+                </tr>
+              </table>
+              <p style="margin: 0 0 16px; font-size: 16px; font-weight: 600; color: #18181b; text-align: center;">
+                Evaluation {{ status_label }}
+              </p>
+              <p style="margin: 0 0 24px; font-size: 14px; line-height: 1.6; color: #3f3f46; text-align: center;">
+                Your evaluation run <strong>{{ run_name }}</strong> has finished.
+              </p>
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin: 0 0 24px; background-color: #fafafa; border-radius: 6px;">
+                <tr>
+                  <td style="padding: 16px 20px; font-size: 13px; color: #52525b;">
+                    <p style="margin: 0 0 8px;"><strong style="color: #18181b;">Eval name:</strong> {{ run_name }}</p>
+                    <p style="margin: 0 0 8px;"><strong style="color: #18181b;">Project:</strong> {{ project_name }}</p>
+                    <p style="margin: 0 0 8px;"><strong style="color: #18181b;">Status:</strong> {{ status_label }}</p>
+                    <p style="margin: 0;"><strong style="color: #18181b;">Completed at:</strong> {{ completed_at }}</p>
+                    {% if error_message %}
+                    <p style="margin: 12px 0 0; color: #b91c1c;"><strong style="color: #b91c1c;">Error:</strong> {{ error_message }}</p>
+                    {% endif %}
+                  </td>
+                </tr>
+              </table>
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 auto;">
+                <tr>
+                  <td align="center" style="background-color: #2563eb; border-radius: 10px;">
+                    <a href="{{ link }}" target="_blank" style="display: inline-block; padding: 10px 30px; font-size: 15px; font-weight: 600; color: #ffffff; text-decoration: none;">
+                      View Results
+                    </a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 24px 0 0; font-size: 12px; color: #a1a1aa; line-height: 1.6; text-align: center;">
+                You're receiving this email because you're a member of the {{ project_name }} project.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/backend/app/email-templates/build/eval_completion.html
+++ b/backend/app/email-templates/build/eval_completion.html
@@ -3,59 +3,90 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Evaluation {{ status_label }} - {{ run_name }}</title>
+  <meta name="color-scheme" content="light only">
+  <meta name="supported-color-schemes" content="light only">
+  <title>{{ app_name }} - Evaluation {{ status_label }}</title>
 </head>
-<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background-color: #f4f4f5;">
+<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background-color: #f6f7f9; color: #1f2937;">
   <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
     <tr>
-      <td style="padding: 60px 20px;">
-        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width: 560px; margin: 0 auto;">
+      <td align="center" style="padding: 48px 16px;">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width: 520px; background-color: #ffffff; border: 1px solid #e5e7eb; border-radius: 12px;">
+
           <tr>
-            <td style="background-color: #ffffff; padding: 48px 40px;">
-              <h1 style="margin: 0 0 4px; font-size: 22px; font-weight: 600; color: #18181b; text-align: center;">
+            <td style="padding: 32px 40px 8px;">
+              <p style="margin: 0; font-size: 14px; font-weight: 600; color: #1f4496; letter-spacing: 0.2px; text-align: center;">
                 {{ app_name }}
+              </p>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding: 16px 40px 8px;">
+              <h1 style="margin: 0 0 12px; font-size: 22px; font-weight: 600; color: #111827; line-height: 1.35;">
+                Evaluation {{ status_label|lower }}
               </h1>
-              <p style="margin: 0 0 20px; font-size: 14px; color: #a1a1aa; text-align: center;">
-                {{ project_name }}
+              <p style="margin: 0; font-size: 15px; line-height: 1.6; color: #4b5563;">
+                Your evaluation run <strong style="color: #111827; font-weight: 600;">{{ run_name }}</strong> in <strong style="color: #111827; font-weight: 600;">{{ project_name }}</strong> has finished.
               </p>
-              <table role="presentation" width="40" cellspacing="0" cellpadding="0" border="0" style="margin: 0 auto 20px;">
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding: 24px 40px 8px;">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="border-top: 1px solid #e5e7eb;">
                 <tr>
-                  <td style="border-top: 2px solid #e4e4e7;"></td>
+                  <td style="padding: 14px 0; font-size: 13px; color: #6b7280; width: 120px;">Evaluation</td>
+                  <td style="padding: 14px 0; font-size: 13px; color: #111827; font-weight: 500;">{{ run_name }}</td>
+                </tr>
+                <tr>
+                  <td style="padding: 14px 0; font-size: 13px; color: #6b7280; border-top: 1px solid #f3f4f6;">Project</td>
+                  <td style="padding: 14px 0; font-size: 13px; color: #111827; font-weight: 500; border-top: 1px solid #f3f4f6;">{{ project_name }}</td>
+                </tr>
+                <tr>
+                  <td style="padding: 14px 0; font-size: 13px; color: #6b7280; border-top: 1px solid #f3f4f6;">Status</td>
+                  <td style="padding: 14px 0; font-size: 13px; color: #111827; font-weight: 500; border-top: 1px solid #f3f4f6;">{{ status_label }}</td>
+                </tr>
+                <tr>
+                  <td style="padding: 14px 0; font-size: 13px; color: #6b7280; border-top: 1px solid #f3f4f6;">Completed</td>
+                  <td style="padding: 14px 0; font-size: 13px; color: #111827; font-weight: 500; border-top: 1px solid #f3f4f6;">{{ completed_at }}</td>
                 </tr>
               </table>
-              <p style="margin: 0 0 16px; font-size: 16px; font-weight: 600; color: #18181b; text-align: center;">
-                Evaluation {{ status_label }}
+            </td>
+          </tr>
+
+          {% if error_message %}
+          <tr>
+            <td style="padding: 8px 40px 0;">
+              <p style="margin: 0; font-size: 13px; line-height: 1.6; color: #b91c1c;">
+                <strong style="font-weight: 600;">Error:</strong> {{ error_message }}
               </p>
-              <p style="margin: 0 0 24px; font-size: 14px; line-height: 1.6; color: #3f3f46; text-align: center;">
-                Your evaluation run <strong>{{ run_name }}</strong> has finished.
-              </p>
-              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin: 0 0 24px; background-color: #fafafa; border-radius: 6px;">
+            </td>
+          </tr>
+          {% endif %}
+
+          <tr>
+            <td align="center" style="padding: 28px 40px 8px;">
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0">
                 <tr>
-                  <td style="padding: 16px 20px; font-size: 13px; color: #52525b;">
-                    <p style="margin: 0 0 8px;"><strong style="color: #18181b;">Eval name:</strong> {{ run_name }}</p>
-                    <p style="margin: 0 0 8px;"><strong style="color: #18181b;">Project:</strong> {{ project_name }}</p>
-                    <p style="margin: 0 0 8px;"><strong style="color: #18181b;">Status:</strong> {{ status_label }}</p>
-                    <p style="margin: 0;"><strong style="color: #18181b;">Completed at:</strong> {{ completed_at }}</p>
-                    {% if error_message %}
-                    <p style="margin: 12px 0 0; color: #b91c1c;"><strong style="color: #b91c1c;">Error:</strong> {{ error_message }}</p>
-                    {% endif %}
-                  </td>
-                </tr>
-              </table>
-              <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 auto;">
-                <tr>
-                  <td align="center" style="background-color: #2563eb; border-radius: 10px;">
-                    <a href="{{ link }}" target="_blank" style="display: inline-block; padding: 10px 30px; font-size: 15px; font-weight: 600; color: #ffffff; text-decoration: none;">
+                  <td style="background-color: #1f4496; border-radius: 999px;">
+                    <a href="{{ link }}" target="_blank" style="display: inline-block; padding: 12px 36px; font-size: 14px; font-weight: 600; color: #ffffff; text-decoration: none;">
                       View Results
                     </a>
                   </td>
                 </tr>
               </table>
-              <p style="margin: 24px 0 0; font-size: 12px; color: #a1a1aa; line-height: 1.6; text-align: center;">
-                You're receiving this email because you're a member of the {{ project_name }} project.
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding: 24px 40px 32px;">
+              <p style="margin: 0; font-size: 12px; line-height: 1.6; color: #9ca3af; text-align: center;">
+                You're receiving this because you're a member of {{ project_name }} on {{ app_name }}.
               </p>
             </td>
           </tr>
+
         </table>
       </td>
     </tr>

--- a/backend/app/email-templates/build/invite_user.html
+++ b/backend/app/email-templates/build/invite_user.html
@@ -32,7 +32,7 @@
               <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 auto;">
                 <tr>
                   <td align="center" style="background-color: #2563eb; border-radius: 10px;">
-                    <a href="{{ link }}" target="_blank" style="display: inline-block; padding: 10px 30px; font-size: 15px; font-weight: 600; color: #ffffff; text-decoration: none;">
+                    <a href="{{ link }}" target="_blank" style="display: inline-block; padding: 10px 30px; font-size: 15px; font-weight: 600; color: #ffffff; border-radius: 999px; text-decoration: none;">
                       Accept Invitation
                     </a>
                   </td>

--- a/backend/app/email-templates/build/invite_user.html
+++ b/backend/app/email-templates/build/invite_user.html
@@ -1,52 +1,139 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>You're invited to {{ project_name }}</title>
-</head>
-<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background-color: #f4f4f5;">
-  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
-    <tr>
-      <td style="padding: 60px 20px;">
-        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width: 520px; margin: 0 auto;">
-          <tr>
-            <td align="center" style="background-color: #ffffff; padding: 48px 40px; text-align: center;">
-              <h1 style="margin: 0 0 4px; font-size: 22px; font-weight: 600; color: #18181b;">
-                {{ app_name }}
-              </h1>
-              <p style="margin: 0 0 20px; font-size: 14px; color: #a1a1aa;">
-                {{ organization_name }}
-              </p>
-              <table role="presentation" width="40" cellspacing="0" cellpadding="0" border="0" style="margin: 0 auto 20px;">
-                <tr>
-                  <td style="border-top: 2px solid #e4e4e7;"></td>
-                </tr>
-              </table>
-              <p style="margin: 0 0 5px; font-size: 15px; line-height: 1.7; color: #3f3f46;">
-                You have been invited to join the <strong>{{ project_name }}</strong> project on {{ app_name }}.
-              </p>
-              <p style="margin: 0 0 20px; font-size: 15px; line-height: 1.7; color: #3f3f46;">
-                Click the button below to accept the invitation and get started.
-              </p>
-              <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 auto;">
-                <tr>
-                  <td align="center" style="background-color: #2563eb; border-radius: 10px;">
-                    <a href="{{ link }}" target="_blank" style="display: inline-block; padding: 10px 30px; font-size: 15px; font-weight: 600; color: #ffffff; border-radius: 999px; text-decoration: none;">
-                      Accept Invitation
-                    </a>
-                  </td>
-                </tr>
-              </table>
-              <p style="margin: 20px 0 0; font-size: 12px; color: #a1a1aa; line-height: 1.6;">
-                This invitation expires in {{ valid_days }} days.<br>
-                If you did not expect this invitation, you can safely ignore this email.
-              </p>
-            </td>
-          </tr>
-        </table>
-      </td>
-    </tr>
-  </table>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>You're invited to {{ project_name }}</title>
+  </head>
+  <body
+    style="
+      margin: 0;
+      padding: 0;
+      font-family:
+        -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto,
+        Helvetica, Arial, sans-serif;
+      background-color: #f4f4f5;
+    "
+  >
+    <table
+      role="presentation"
+      width="100%"
+      cellspacing="0"
+      cellpadding="0"
+      border="0"
+    >
+      <tr>
+        <td style="padding: 60px 20px">
+          <table
+            role="presentation"
+            width="100%"
+            cellspacing="0"
+            cellpadding="0"
+            border="0"
+            style="max-width: 520px; margin: 0 auto"
+          >
+            <tr>
+              <td
+                align="center"
+                style="
+                  background-color: #ffffff;
+                  padding: 48px 40px;
+                  text-align: center;
+                "
+              >
+                <h1
+                  style="
+                    margin: 0 0 4px;
+                    font-size: 22px;
+                    font-weight: 600;
+                    color: #18181b;
+                  "
+                >
+                  {{ app_name }}
+                </h1>
+                <p style="margin: 0 0 20px; font-size: 14px; color: #a1a1aa">
+                  {{ organization_name }}
+                </p>
+                <table
+                  role="presentation"
+                  width="40"
+                  cellspacing="0"
+                  cellpadding="0"
+                  border="0"
+                  style="margin: 0 auto 20px"
+                >
+                  <tr>
+                    <td style="border-top: 2px solid #e4e4e7"></td>
+                  </tr>
+                </table>
+                <p
+                  style="
+                    margin: 0 0 5px;
+                    font-size: 15px;
+                    line-height: 1.7;
+                    color: #3f3f46;
+                  "
+                >
+                  You have been invited to join the
+                  <strong>{{ project_name }}</strong> project on {{ app_name }}.
+                </p>
+                <p
+                  style="
+                    margin: 0 0 20px;
+                    font-size: 15px;
+                    line-height: 1.7;
+                    color: #3f3f46;
+                  "
+                >
+                  Click the button below to accept the invitation and get
+                  started.
+                </p>
+                <table
+                  role="presentation"
+                  cellspacing="0"
+                  cellpadding="0"
+                  border="0"
+                  style="margin: 0 auto"
+                >
+                  <tr>
+                    <td
+                      align="center"
+                      style="background-color: #1f4496; border-radius: 999px"
+                    >
+                      <a
+                        href="{{ link }}"
+                        target="_blank"
+                        style="
+                          display: inline-block;
+                          padding: 10px 30px;
+                          font-size: 15px;
+                          font-weight: 600;
+                          color: #ffffff;
+                          text-decoration: none;
+                        "
+                      >
+                        Accept Invitation
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+                <p
+                  style="
+                    margin: 20px 0 0;
+                    font-size: 12px;
+                    color: #a1a1aa;
+                    line-height: 1.6;
+                  "
+                >
+                  This invitation expires in {{ valid_days }} days.<br />
+                  If you did not expect this invitation, you can safely ignore
+                  this email.
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
 </html>

--- a/backend/app/email-templates/build/magic_link_login.html
+++ b/backend/app/email-templates/build/magic_link_login.html
@@ -1,52 +1,134 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Sign in to {{ app_name }}</title>
-</head>
-<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background-color: #f4f4f5;">
-  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
-    <tr>
-      <td style="padding: 60px 20px;">
-        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width: 520px; margin: 0 auto;">
-          <tr>
-            <td align="center" style="background-color: #ffffff; padding: 48px 40px; text-align: center;">
-              <h1 style="margin: 0 0 4px; font-size: 22px; font-weight: 600; color: #18181b;">
-                {{ app_name }}
-              </h1>
-              <p style="margin: 0 0 20px; font-size: 14px; color: #a1a1aa;">
-                Sign in to your account
-              </p>
-              <table role="presentation" width="40" cellspacing="0" cellpadding="0" border="0" style="margin: 0 auto 20px;">
-                <tr>
-                  <td style="border-top: 2px solid #e4e4e7;"></td>
-                </tr>
-              </table>
-              <p style="margin: 0 0 5px; font-size: 15px; line-height: 1.7; color: #3f3f46;">
-                We received a sign-in request for <strong>{{ email }}</strong>.
-              </p>
-              <p style="margin: 0 0 20px; font-size: 15px; line-height: 1.7; color: #3f3f46;">
-                Click the button below to sign in.
-              </p>
-              <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 auto;">
-                <tr>
-                  <td align="center" style="background-color: #2563eb; border-radius: 10px;">
-                    <a href="{{ link }}" target="_blank" style="display: inline-block; padding: 10px 30px; font-size: 15px; font-weight: 600; color: #ffffff; text-decoration: none;">
-                      Sign In Now
-                    </a>
-                  </td>
-                </tr>
-              </table>
-              <p style="margin: 20px 0 0; font-size: 12px; color: #a1a1aa; line-height: 1.6;">
-                This link expires in {{ valid_minutes }} minutes.<br>
-                If you did not request this, you can safely ignore this email.
-              </p>
-            </td>
-          </tr>
-        </table>
-      </td>
-    </tr>
-  </table>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sign in to {{ app_name }}</title>
+  </head>
+  <body
+    style="
+      margin: 0;
+      padding: 0;
+      font-family:
+        -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto,
+        Helvetica, Arial, sans-serif;
+      background-color: #f4f4f5;
+    "
+  >
+    <table
+      role="presentation"
+      width="100%"
+      cellspacing="0"
+      cellpadding="0"
+      border="0"
+    >
+      <tr>
+        <td style="padding: 60px 20px">
+          <table
+            role="presentation"
+            width="100%"
+            cellspacing="0"
+            cellpadding="0"
+            border="0"
+            style="max-width: 520px; margin: 0 auto"
+          >
+            <tr>
+              <td
+                align="center"
+                style="
+                  background-color: #ffffff;
+                  padding: 48px 40px;
+                  text-align: center;
+                "
+              >
+                <h1
+                  style="
+                    margin: 0 0 4px;
+                    font-size: 22px;
+                    font-weight: 600;
+                    color: #18181b;
+                  "
+                >
+                  {{ app_name }}
+                </h1>
+                <p style="margin: 0 0 20px; font-size: 14px; color: #a1a1aa">
+                  Sign in to your account
+                </p>
+                <table
+                  role="presentation"
+                  width="40"
+                  cellspacing="0"
+                  cellpadding="0"
+                  border="0"
+                  style="margin: 0 auto 20px"
+                >
+                  <tr>
+                    <td style="border-top: 2px solid #e4e4e7"></td>
+                  </tr>
+                </table>
+                <p
+                  style="
+                    margin: 0 0 5px;
+                    font-size: 15px;
+                    line-height: 1.7;
+                    color: #3f3f46;
+                  "
+                >
+                  We received a sign-in request for
+                  <strong>{{ email }}</strong>.
+                </p>
+                <p
+                  style="
+                    margin: 0 0 20px;
+                    font-size: 15px;
+                    line-height: 1.7;
+                    color: #3f3f46;
+                  "
+                >
+                  Click the button below to sign in.
+                </p>
+                <table
+                  role="presentation"
+                  cellspacing="0"
+                  cellpadding="0"
+                  border="0"
+                  style="margin: 0 auto"
+                >
+                  <tr>
+                    <td style="background-color: #1f4496; border-radius: 999px">
+                      <a
+                        href="{{ link }}"
+                        target="_blank"
+                        style="
+                          display: inline-block;
+                          padding: 10px 30px;
+                          font-size: 15px;
+                          font-weight: 600;
+                          color: #ffffff;
+                          text-decoration: none;
+                        "
+                      >
+                        Sign In Now
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+                <p
+                  style="
+                    margin: 20px 0 0;
+                    font-size: 12px;
+                    color: #a1a1aa;
+                    line-height: 1.6;
+                  "
+                >
+                  This link expires in {{ valid_minutes }} minutes.<br />
+                  If you did not request this, you can safely ignore this email.
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
 </html>

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -141,6 +141,13 @@ from .model_evaluation import (
     ModelEvaluationStatus,
     ModelEvaluationUpdate,
 )
+from .notification import (
+    Notification,
+    NotificationEntityType,
+    NotificationProvider,
+    NotificationStatus,
+    NotificationType,
+)
 from .onboarding import OnboardingRequest, OnboardingResponse
 from .openai_conversation import (
     OpenAIConversation,

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -27,6 +27,7 @@ class NotificationType(str, Enum):
     EVAL_COMPLETED = "eval_completed"
     EVAL_FAILED = "eval_failed"
     MAGIC_LINK_LOGIN = "magic_link_login"
+    INVITE_USER = "invite_user"
 
 
 class NotificationEntityType(str, Enum):

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
-from sqlalchemy import Column, Index
+from sqlalchemy import Column, Index, String
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, SQLModel
 
@@ -56,7 +56,7 @@ class Notification(SQLModel, table=True):
         Index("idx_notification_status", "status"),
     )
 
-    id: int = Field(
+    id: int | None = Field(
         default=None,
         primary_key=True,
         sa_column_kwargs={"comment": "Unique identifier for the notification record"},
@@ -84,10 +84,12 @@ class Notification(SQLModel, table=True):
             "comment": "Reference to the user receiving the notification"
         },
     )
-    entity_type: str = Field(
-        max_length=64,
-        nullable=False,
-        sa_column_kwargs={"comment": "Polymorphic entity type, e.g. eval_run, project"},
+    entity_type: NotificationEntityType = Field(
+        sa_column=Column(
+            String(64),
+            nullable=False,
+            comment="Polymorphic entity type, e.g. eval_run, project, user",
+        ),
     )
     entity_id: int = Field(
         nullable=False,

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -1,0 +1,161 @@
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from sqlalchemy import Column, Index
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlmodel import Field, SQLModel
+
+from app.core.util import now
+
+
+class NotificationStatus(str, Enum):
+    PENDING = "pending"
+    SENT = "sent"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+class NotificationProvider(str, Enum):
+    EMAIL = "email"
+    PUSH = "push"
+    SMS = "sms"
+    WEBHOOK = "webhook"
+
+
+class NotificationType(str, Enum):
+    EVAL_COMPLETED = "eval_completed"
+    EVAL_FAILED = "eval_failed"
+    MAGIC_LINK_LOGIN = "magic_link_login"
+
+
+class NotificationEntityType(str, Enum):
+    EVAL_RUN = "eval_run"
+    PROJECT = "project"
+    USER = "user"
+
+
+class Notification(SQLModel, table=True):
+    """Generic outbound notification record.
+
+    One row per (recipient, channel, event). Existence of rows for a given
+    (entity_type, entity_id, notification_type) is used as the idempotency
+    guard preventing duplicate sends for the same event.
+    """
+
+    __tablename__ = "notification"
+    __table_args__ = (
+        Index(
+            "idx_notification_entity",
+            "entity_type",
+            "entity_id",
+            "notification_type",
+        ),
+        Index("idx_notification_recipient", "recipient_user_id"),
+        Index("idx_notification_status", "status"),
+    )
+
+    id: int = Field(
+        default=None,
+        primary_key=True,
+        sa_column_kwargs={"comment": "Unique identifier for the notification record"},
+    )
+    notification_type: str = Field(
+        max_length=64,
+        nullable=False,
+        sa_column_kwargs={
+            "comment": (
+                "Event triggering the notification, e.g. eval_completed, "
+                "eval_failed, magic_link_login"
+            )
+        },
+    )
+    provider: str = Field(
+        max_length=32,
+        nullable=False,
+        sa_column_kwargs={"comment": "Delivery channel: email, push, sms, webhook"},
+    )
+    recipient_user_id: int = Field(
+        foreign_key="user.id",
+        nullable=False,
+        ondelete="CASCADE",
+        sa_column_kwargs={
+            "comment": "Reference to the user receiving the notification"
+        },
+    )
+    entity_type: str = Field(
+        max_length=64,
+        nullable=False,
+        sa_column_kwargs={"comment": "Polymorphic entity type, e.g. eval_run, project"},
+    )
+    entity_id: int = Field(
+        nullable=False,
+        sa_column_kwargs={
+            "comment": "Polymorphic entity id (not a hard FK across types)"
+        },
+    )
+    project_id: int | None = Field(
+        default=None,
+        foreign_key="project.id",
+        nullable=True,
+        ondelete="CASCADE",
+        sa_column_kwargs={
+            "comment": (
+                "Reference to the project the notification belongs to. "
+                "Null for project-agnostic notifications (e.g. magic_link_login)."
+            )
+        },
+    )
+    subject: str | None = Field(
+        default=None,
+        nullable=True,
+        sa_column_kwargs={"comment": "Subject line (for email-like providers)"},
+    )
+    body_template: str | None = Field(
+        default=None,
+        max_length=128,
+        nullable=True,
+        sa_column_kwargs={
+            "comment": (
+                "Template identifier used to render the body, "
+                "e.g. eval_completion_v1"
+            )
+        },
+    )
+    payload: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(
+            JSONB,
+            nullable=False,
+            comment=(
+                "Snapshot of dynamic values used to render the notification "
+                "(eval name, status, timestamp, result link, etc.)"
+            ),
+        ),
+    )
+    status: str = Field(
+        default=NotificationStatus.PENDING.value,
+        max_length=16,
+        nullable=False,
+        sa_column_kwargs={"comment": "Delivery status: pending, sent, failed, skipped"},
+    )
+    sent_at: datetime | None = Field(
+        default=None,
+        nullable=True,
+        sa_column_kwargs={"comment": "Timestamp when delivery succeeded"},
+    )
+    failed_reason: str | None = Field(
+        default=None,
+        nullable=True,
+        sa_column_kwargs={"comment": "Error message if delivery failed"},
+    )
+    inserted_at: datetime = Field(
+        default_factory=now,
+        nullable=False,
+        sa_column_kwargs={"comment": "Timestamp when the record was created"},
+    )
+    updated_at: datetime = Field(
+        default_factory=now,
+        nullable=False,
+        sa_column_kwargs={"comment": "Timestamp when the record was last updated"},
+    )

--- a/backend/app/tests/api/test_auth.py
+++ b/backend/app/tests/api/test_auth.py
@@ -362,6 +362,70 @@ class TestMagicLink:
         assert "login link has been sent" in resp.json()["data"]["message"]
         mock_send.assert_called_once()
 
+    @patch("app.api.routes.auth.send_email")
+    @patch("app.api.routes.auth.settings")
+    def test_magic_link_records_sent_notification(
+        self, mock_settings, mock_send, db: Session, client: TestClient
+    ):
+        """Magic-link send writes a 'sent' row to the notification table."""
+        from sqlmodel import select
+
+        from app.models import Notification, NotificationStatus, NotificationType
+
+        user = create_random_user(db)
+        mock_settings.emails_enabled = True
+        mock_settings.MAGIC_LINK_TOKEN_EXPIRE_MINUTES = 15
+        mock_settings.SECRET_KEY = settings.SECRET_KEY
+        mock_settings.FRONTEND_HOST = "http://localhost:3000"
+        mock_settings.PROJECT_NAME = "Kaapi"
+
+        resp = client.post(MAGIC_LINK_URL, json={"email": user.email})
+        assert resp.status_code == 200
+
+        rows = db.exec(
+            select(Notification).where(
+                Notification.recipient_user_id == user.id,
+                Notification.notification_type
+                == NotificationType.MAGIC_LINK_LOGIN.value,
+            )
+        ).all()
+        assert len(rows) == 1
+        assert rows[0].status == NotificationStatus.SENT.value
+        assert rows[0].sent_at is not None
+        assert rows[0].payload["email"] == user.email
+        assert rows[0].payload["valid_minutes"] == 15
+
+    @patch("app.api.routes.auth.send_email", side_effect=RuntimeError("smtp dead"))
+    @patch("app.api.routes.auth.settings")
+    def test_magic_link_records_failed_notification_on_smtp_error(
+        self, mock_settings, mock_send, db: Session, client: TestClient
+    ):
+        """SMTP errors during magic-link send flip the row to 'failed' with a reason."""
+        from sqlmodel import select
+
+        from app.models import Notification, NotificationStatus, NotificationType
+
+        user = create_random_user(db)
+        mock_settings.emails_enabled = True
+        mock_settings.MAGIC_LINK_TOKEN_EXPIRE_MINUTES = 15
+        mock_settings.SECRET_KEY = settings.SECRET_KEY
+        mock_settings.FRONTEND_HOST = "http://localhost:3000"
+        mock_settings.PROJECT_NAME = "Kaapi"
+
+        resp = client.post(MAGIC_LINK_URL, json={"email": user.email})
+        assert resp.status_code == 500
+
+        rows = db.exec(
+            select(Notification).where(
+                Notification.recipient_user_id == user.id,
+                Notification.notification_type
+                == NotificationType.MAGIC_LINK_LOGIN.value,
+            )
+        ).all()
+        assert len(rows) == 1
+        assert rows[0].status == NotificationStatus.FAILED.value
+        assert "smtp dead" in rows[0].failed_reason
+
 
 class TestMagicLinkVerify:
     """Test suite for GET /auth/magic-link/verify endpoint."""

--- a/backend/app/tests/api/test_user_project.py
+++ b/backend/app/tests/api/test_user_project.py
@@ -135,6 +135,103 @@ class TestAddProjectUsers:
         assert resp.status_code == 201
         mock_send_email.assert_called_once()
 
+    @patch("app.api.routes.user_project.send_email")
+    @patch("app.api.routes.user_project.settings")
+    def test_invite_creates_sent_notification_row(
+        self,
+        mock_settings,
+        mock_send_email,
+        db: Session,
+        client: TestClient,
+        superuser_token_headers: dict[str, str],
+    ):
+        """Each invite send records a 'sent' row in the notification table."""
+        from app.crud import get_user_by_email
+        from app.models import Notification, NotificationStatus, NotificationType
+
+        project = create_test_project(db)
+        email = random_email()
+
+        mock_settings.emails_enabled = True
+        mock_settings.INVITE_TOKEN_EXPIRE_HOURS = 168
+        mock_settings.SECRET_KEY = settings.SECRET_KEY
+        mock_settings.FRONTEND_HOST = "http://localhost:3000"
+        mock_settings.PROJECT_NAME = "Kaapi"
+
+        resp = client.post(
+            USER_PROJECTS_URL,
+            json={
+                "organization_id": project.organization_id,
+                "project_id": project.id,
+                "users": [{"email": email}],
+            },
+            headers=superuser_token_headers,
+        )
+        assert resp.status_code == 201
+        invited = get_user_by_email(session=db, email=email)
+        assert invited is not None
+
+        rows = db.exec(
+            select(Notification).where(
+                Notification.recipient_user_id == invited.id,
+                Notification.notification_type == NotificationType.INVITE_USER.value,
+            )
+        ).all()
+        assert len(rows) == 1
+        assert rows[0].status == NotificationStatus.SENT.value
+        assert rows[0].project_id == project.id
+        assert rows[0].payload["email"] == email
+        assert rows[0].payload["project_name"] == project.name
+
+    @patch(
+        "app.api.routes.user_project.send_email",
+        side_effect=RuntimeError("smtp dead"),
+    )
+    @patch("app.api.routes.user_project.settings")
+    def test_invite_records_failed_notification_on_smtp_error(
+        self,
+        mock_settings,
+        mock_send_email,
+        db: Session,
+        client: TestClient,
+        superuser_token_headers: dict[str, str],
+    ):
+        """SMTP failures during invite write a 'failed' row but the response still succeeds."""
+        from app.crud import get_user_by_email
+        from app.models import Notification, NotificationStatus, NotificationType
+
+        project = create_test_project(db)
+        email = random_email()
+
+        mock_settings.emails_enabled = True
+        mock_settings.INVITE_TOKEN_EXPIRE_HOURS = 168
+        mock_settings.SECRET_KEY = settings.SECRET_KEY
+        mock_settings.FRONTEND_HOST = "http://localhost:3000"
+        mock_settings.PROJECT_NAME = "Kaapi"
+
+        resp = client.post(
+            USER_PROJECTS_URL,
+            json={
+                "organization_id": project.organization_id,
+                "project_id": project.id,
+                "users": [{"email": email}],
+            },
+            headers=superuser_token_headers,
+        )
+        # Invite endpoint swallows send failures (just logs) and still returns 201
+        assert resp.status_code == 201
+
+        invited = get_user_by_email(session=db, email=email)
+        rows = db.exec(
+            select(Notification).where(
+                Notification.recipient_user_id == invited.id,
+                Notification.notification_type == NotificationType.INVITE_USER.value,
+            )
+        ).all()
+        assert len(rows) == 1
+        assert rows[0].status == NotificationStatus.FAILED.value
+        assert "smtp dead" in rows[0].failed_reason
+
     def test_add_duplicate_user_same_project(
         self,
         db: Session,

--- a/backend/app/tests/celery/test_notifications.py
+++ b/backend/app/tests/celery/test_notifications.py
@@ -84,8 +84,27 @@ class TestHelperFunctions:
         with patch.object(notif_task.settings, "FRONTEND_HOST", "http://example.com"):
             assert (
                 notif_task._build_eval_results_link(eval_run)
-                == "http://example.com/evaluations/"
+                == "http://example.com/evaluations/46"
             )
+
+    def test_format_completed_at_strips_leading_zero(self):
+        assert (
+            notif_task._format_completed_at(datetime(2026, 5, 16, 6, 5))
+            == "May 16, 2026 at 6:05 AM"
+        )
+
+    def test_format_completed_at_handles_noon_and_midnight(self):
+        assert (
+            notif_task._format_completed_at(datetime(2026, 5, 16, 12, 0))
+            == "May 16, 2026 at 12:00 PM"
+        )
+        assert (
+            notif_task._format_completed_at(datetime(2026, 5, 16, 0, 5))
+            == "May 16, 2026 at 12:05 AM"
+        )
+
+    def test_format_completed_at_returns_empty_for_none(self):
+        assert notif_task._format_completed_at(None) == ""
 
     def test_notification_type_for_status_failed(self):
         assert (
@@ -116,8 +135,8 @@ class TestHelperFunctions:
             "run_name": "exp1",
             "project_name": "ProjX",
             "status": "completed",
-            "completed_at": "2026-05-16T18:33:50",
-            "link": "http://example.com/evaluations/",
+            "completed_at": "May 16, 2026 at 6:33 PM",
+            "link": "http://example.com/evaluations/99",
             "error_message": None,
         }
 

--- a/backend/app/tests/celery/test_notifications.py
+++ b/backend/app/tests/celery/test_notifications.py
@@ -1,0 +1,274 @@
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlmodel import Session, select
+
+from app.celery.tasks import notifications as notif_task
+from app.crud.user_project import add_user_to_project
+from app.models import (
+    EvaluationRun,
+    Notification,
+    NotificationEntityType,
+    NotificationStatus,
+    NotificationType,
+    Project,
+)
+from app.tests.utils.test_data import create_test_project
+from app.tests.utils.utils import random_email
+
+
+class _NonClosingSession:
+    """Context-manager wrapper that yields a real session without closing it.
+
+    The Celery task opens `Session(engine)` for its own scope; in tests we
+    point that at the conftest's transactional session so changes roll back
+    at the end of the test.
+    """
+
+    def __init__(self, session: Session):
+        self._session = session
+
+    def __enter__(self) -> Session:
+        return self._session
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+@pytest.fixture
+def patched_session(db: Session):
+    with patch(
+        "app.celery.tasks.notifications.Session",
+        side_effect=lambda _engine: _NonClosingSession(db),
+    ):
+        yield db
+
+
+def _make_eval_run(
+    db: Session,
+    *,
+    project: Project,
+    status: str = "completed",
+    error_message: str | None = None,
+) -> EvaluationRun:
+    run = EvaluationRun(
+        run_name=f"test_run_{random_email()}",
+        dataset_name="dataset_x",
+        dataset_id=1,
+        type="text",
+        status=status,
+        organization_id=project.organization_id,
+        project_id=project.id,
+        updated_at=datetime(2026, 5, 16, 18, 33, 50),
+        inserted_at=datetime(2026, 5, 16, 18, 0, 0),
+        error_message=error_message,
+    )
+    db.add(run)
+    db.commit()
+    db.refresh(run)
+    return run
+
+
+class TestHelperFunctions:
+    def test_build_eval_results_link(self):
+        eval_run = MagicMock(project_id=1, id=46)
+        with patch.object(notif_task.settings, "FRONTEND_HOST", "http://example.com"):
+            assert (
+                notif_task._build_eval_results_link(eval_run)
+                == "http://example.com/evaluations/"
+            )
+
+    def test_notification_type_for_status_failed(self):
+        assert (
+            notif_task._notification_type_for_status("failed")
+            == NotificationType.EVAL_FAILED.value
+        )
+
+    def test_notification_type_for_status_completed(self):
+        assert (
+            notif_task._notification_type_for_status("completed")
+            == NotificationType.EVAL_COMPLETED.value
+        )
+
+    def test_build_payload_includes_all_fields(self):
+        eval_run = MagicMock(
+            run_name="exp1",
+            project_id=2,
+            id=99,
+            status="completed",
+            updated_at=datetime(2026, 5, 16, 18, 33, 50),
+            error_message=None,
+        )
+        with patch.object(notif_task.settings, "FRONTEND_HOST", "http://example.com"):
+            payload = notif_task._build_eval_completion_payload(
+                eval_run=eval_run, project_name="ProjX"
+            )
+        assert payload == {
+            "run_name": "exp1",
+            "project_name": "ProjX",
+            "status": "completed",
+            "completed_at": "2026-05-16T18:33:50",
+            "link": "http://example.com/evaluations/",
+            "error_message": None,
+        }
+
+
+class TestSendEvalCompletionNotification:
+    def test_returns_not_found_when_eval_missing(self, patched_session: Session):
+        result = notif_task.send_eval_completion_notification.apply(
+            args=[99999999]
+        ).result
+        assert result == {
+            "evaluation_id": 99999999,
+            "sent": 0,
+            "failed": 0,
+            "not_found": True,
+        }
+
+    def test_skips_when_already_processed(self, patched_session: Session):
+        project = create_test_project(patched_session)
+        run = _make_eval_run(patched_session, project=project)
+
+        # Pre-existing notification row simulates a prior fan-out
+        existing = Notification(
+            notification_type=NotificationType.EVAL_COMPLETED.value,
+            provider="email",
+            recipient_user_id=1,
+            entity_type=NotificationEntityType.EVAL_RUN.value,
+            entity_id=run.id,
+            project_id=project.id,
+            payload={},
+            status=NotificationStatus.SENT.value,
+        )
+        patched_session.add(existing)
+        patched_session.commit()
+
+        result = notif_task.send_eval_completion_notification.apply(
+            args=[run.id]
+        ).result
+        assert result["skipped"] is True
+        assert result["sent"] == 0
+
+    def test_skips_when_emails_disabled(self, patched_session: Session):
+        project = create_test_project(patched_session)
+        run = _make_eval_run(patched_session, project=project)
+
+        with patch.object(notif_task.settings, "emails_enabled", False):
+            result = notif_task.send_eval_completion_notification.apply(
+                args=[run.id]
+            ).result
+
+        assert result["skipped"] is True
+        # No notification rows created
+        rows = patched_session.exec(
+            select(Notification).where(Notification.entity_id == run.id)
+        ).all()
+        assert rows == []
+
+    def test_no_recipients_returns_zero(self, patched_session: Session):
+        project = create_test_project(patched_session)
+        run = _make_eval_run(patched_session, project=project)
+
+        with patch.object(notif_task.settings, "emails_enabled", True):
+            result = notif_task.send_eval_completion_notification.apply(
+                args=[run.id]
+            ).result
+
+        assert result == {"evaluation_id": run.id, "sent": 0, "failed": 0}
+
+    def test_fans_out_one_email_per_recipient(self, patched_session: Session):
+        project = create_test_project(patched_session)
+        run = _make_eval_run(patched_session, project=project)
+
+        # Add two project members
+        for _ in range(2):
+            add_user_to_project(
+                session=patched_session,
+                email=random_email(),
+                organization_id=project.organization_id,
+                project_id=project.id,
+                full_name="Tester",
+            )
+        patched_session.commit()
+
+        with patch.object(notif_task.settings, "emails_enabled", True), patch.object(
+            notif_task, "send_email"
+        ) as mock_send:
+            result = notif_task.send_eval_completion_notification.apply(
+                args=[run.id]
+            ).result
+
+        assert result["recipients"] == 2
+        assert result["sent"] == 2
+        assert result["failed"] == 0
+        assert mock_send.call_count == 2
+
+        rows = patched_session.exec(
+            select(Notification).where(Notification.entity_id == run.id)
+        ).all()
+        assert len(rows) == 2
+        assert all(r.status == NotificationStatus.SENT.value for r in rows)
+        assert all(r.sent_at is not None for r in rows)
+        assert all(
+            r.notification_type == NotificationType.EVAL_COMPLETED.value for r in rows
+        )
+
+    def test_marks_row_failed_when_smtp_raises(self, patched_session: Session):
+        project = create_test_project(patched_session)
+        run = _make_eval_run(patched_session, project=project)
+        add_user_to_project(
+            session=patched_session,
+            email=random_email(),
+            organization_id=project.organization_id,
+            project_id=project.id,
+        )
+        patched_session.commit()
+
+        with patch.object(notif_task.settings, "emails_enabled", True), patch.object(
+            notif_task, "send_email", side_effect=RuntimeError("SMTP timeout")
+        ):
+            result = notif_task.send_eval_completion_notification.apply(
+                args=[run.id]
+            ).result
+
+        assert result["sent"] == 0
+        assert result["failed"] == 1
+
+        rows = patched_session.exec(
+            select(Notification).where(Notification.entity_id == run.id)
+        ).all()
+        assert len(rows) == 1
+        assert rows[0].status == NotificationStatus.FAILED.value
+        assert "SMTP timeout" in rows[0].failed_reason
+
+    def test_failed_status_uses_eval_failed_type(self, patched_session: Session):
+        project = create_test_project(patched_session)
+        run = _make_eval_run(
+            patched_session,
+            project=project,
+            status="failed",
+            error_message="Batch failed",
+        )
+        add_user_to_project(
+            session=patched_session,
+            email=random_email(),
+            organization_id=project.organization_id,
+            project_id=project.id,
+        )
+        patched_session.commit()
+
+        with patch.object(notif_task.settings, "emails_enabled", True), patch.object(
+            notif_task, "send_email"
+        ):
+            result = notif_task.send_eval_completion_notification.apply(
+                args=[run.id]
+            ).result
+
+        assert result["notification_type"] == NotificationType.EVAL_FAILED.value
+        rows = patched_session.exec(
+            select(Notification).where(Notification.entity_id == run.id)
+        ).all()
+        assert all(
+            r.notification_type == NotificationType.EVAL_FAILED.value for r in rows
+        )

--- a/backend/app/tests/celery/test_notifications.py
+++ b/backend/app/tests/celery/test_notifications.py
@@ -14,7 +14,10 @@ from app.models import (
     NotificationType,
     Project,
 )
-from app.tests.utils.test_data import create_test_project
+from app.tests.utils.test_data import (
+    create_test_evaluation_dataset,
+    create_test_project,
+)
 from app.tests.utils.utils import random_email
 
 
@@ -52,10 +55,15 @@ def _make_eval_run(
     status: str = "completed",
     error_message: str | None = None,
 ) -> EvaluationRun:
+    dataset = create_test_evaluation_dataset(
+        db,
+        organization_id=project.organization_id,
+        project_id=project.id,
+    )
     run = EvaluationRun(
         run_name=f"test_run_{random_email()}",
-        dataset_name="dataset_x",
-        dataset_id=1,
+        dataset_name=dataset.name,
+        dataset_id=dataset.id,
         type="text",
         status=status,
         organization_id=project.organization_id,

--- a/backend/app/tests/celery/test_notifications.py
+++ b/backend/app/tests/celery/test_notifications.py
@@ -81,6 +81,28 @@ class _MultiPatch:
         return False
 
 
+def _add_active_member(db: Session, *, project: Project) -> str:
+    """Add a fresh active user to the project and return their email.
+
+    `add_user_to_project` creates new users with `is_active=False` (so they
+    have to verify via invite before they can log in). The notification task
+    filters those out — so for the fan-out tests we flip the flag immediately
+    after creation to simulate an already-activated project member.
+    """
+    email = random_email()
+    user, _ = add_user_to_project(
+        session=db,
+        email=email,
+        organization_id=project.organization_id,
+        project_id=project.id,
+        full_name="Tester",
+    )
+    user.is_active = True
+    db.add(user)
+    db.commit()
+    return email
+
+
 def _make_eval_run(
     db: Session,
     *,
@@ -124,26 +146,26 @@ class TestHelperFunctions:
         # 18:33 UTC + 5:30 = 00:03 IST next day
         assert (
             notif_task._format_completed_at(datetime(2026, 5, 16, 18, 33))
-            == "May 17, 2026 at 12:03 AM IST"
+            == "May 17, 2026 at 12:03 AM"
         )
 
     def test_format_completed_at_strips_leading_zero(self):
         # 00:35 UTC + 5:30 = 06:05 IST
         assert (
             notif_task._format_completed_at(datetime(2026, 5, 16, 0, 35))
-            == "May 16, 2026 at 6:05 AM IST"
+            == "May 16, 2026 at 6:05 AM"
         )
 
     def test_format_completed_at_handles_noon_and_midnight(self):
         # 06:30 UTC + 5:30 = 12:00 IST (noon)
         assert (
             notif_task._format_completed_at(datetime(2026, 5, 16, 6, 30))
-            == "May 16, 2026 at 12:00 PM IST"
+            == "May 16, 2026 at 12:00 PM"
         )
         # 18:35 UTC + 5:30 = 00:05 IST (midnight next day)
         assert (
             notif_task._format_completed_at(datetime(2026, 5, 16, 18, 35))
-            == "May 17, 2026 at 12:05 AM IST"
+            == "May 17, 2026 at 12:05 AM"
         )
 
     def test_format_completed_at_returns_empty_for_none(self):
@@ -179,7 +201,7 @@ class TestHelperFunctions:
             "run_name": "exp1",
             "project_name": "ProjX",
             "status": "completed",
-            "completed_at": "May 17, 2026 at 12:03 AM IST",
+            "completed_at": "May 17, 2026 at 12:03 AM",
             "link": "http://example.com/evaluations/99",
             "error_message": None,
         }
@@ -252,16 +274,9 @@ class TestSendEvalCompletionNotification:
         project = create_test_project(patched_session)
         run = _make_eval_run(patched_session, project=project)
 
-        # Add two project members
-        for _ in range(2):
-            add_user_to_project(
-                session=patched_session,
-                email=random_email(),
-                organization_id=project.organization_id,
-                project_id=project.id,
-                full_name="Tester",
-            )
-        patched_session.commit()
+        # Two activated project members
+        _add_active_member(patched_session, project=project)
+        _add_active_member(patched_session, project=project)
 
         with _emails_enabled(True), patch.object(notif_task, "send_email") as mock_send:
             result = notif_task.send_eval_completion_notification.apply(
@@ -286,13 +301,7 @@ class TestSendEvalCompletionNotification:
     def test_marks_row_failed_when_smtp_raises(self, patched_session: Session):
         project = create_test_project(patched_session)
         run = _make_eval_run(patched_session, project=project)
-        add_user_to_project(
-            session=patched_session,
-            email=random_email(),
-            organization_id=project.organization_id,
-            project_id=project.id,
-        )
-        patched_session.commit()
+        _add_active_member(patched_session, project=project)
 
         with _emails_enabled(True), patch.object(
             notif_task, "send_email", side_effect=RuntimeError("SMTP timeout")
@@ -319,13 +328,7 @@ class TestSendEvalCompletionNotification:
             status="failed",
             error_message="Batch failed",
         )
-        add_user_to_project(
-            session=patched_session,
-            email=random_email(),
-            organization_id=project.organization_id,
-            project_id=project.id,
-        )
-        patched_session.commit()
+        _add_active_member(patched_session, project=project)
 
         with _emails_enabled(True), patch.object(notif_task, "send_email"):
             result = notif_task.send_eval_completion_notification.apply(

--- a/backend/app/tests/celery/test_notifications.py
+++ b/backend/app/tests/celery/test_notifications.py
@@ -48,6 +48,39 @@ def patched_session(db: Session):
         yield db
 
 
+def _emails_enabled(enabled: bool):
+    """Toggle `settings.emails_enabled` by setting the underlying raw fields.
+
+    `emails_enabled` is a Pydantic `@computed_field`, so `patch.object` can't
+    override it on the instance — it's read-only. Instead, patch the two raw
+    settings it derives from (`SMTP_HOST` + `EMAILS_FROM_EMAIL`) which is what
+    `bool(SMTP_HOST and EMAILS_FROM_EMAIL)` evaluates against.
+    """
+    smtp_host = "smtp.test.local" if enabled else ""
+    from_email = "noreply@test.local" if enabled else ""
+    return _MultiPatch(
+        patch.object(notif_task.settings, "SMTP_HOST", smtp_host),
+        patch.object(notif_task.settings, "EMAILS_FROM_EMAIL", from_email),
+    )
+
+
+class _MultiPatch:
+    """Tiny context manager that enters/exits multiple `patch` objects together."""
+
+    def __init__(self, *patches):
+        self._patches = patches
+
+    def __enter__(self):
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        for p in reversed(self._patches):
+            p.stop()
+        return False
+
+
 def _make_eval_run(
     db: Session,
     *,
@@ -87,20 +120,30 @@ class TestHelperFunctions:
                 == "http://example.com/evaluations/46"
             )
 
-    def test_format_completed_at_strips_leading_zero(self):
+    def test_format_completed_at_converts_utc_to_ist(self):
+        # 18:33 UTC + 5:30 = 00:03 IST next day
         assert (
-            notif_task._format_completed_at(datetime(2026, 5, 16, 6, 5))
-            == "May 16, 2026 at 6:05 AM"
+            notif_task._format_completed_at(datetime(2026, 5, 16, 18, 33))
+            == "May 17, 2026 at 12:03 AM IST"
+        )
+
+    def test_format_completed_at_strips_leading_zero(self):
+        # 00:35 UTC + 5:30 = 06:05 IST
+        assert (
+            notif_task._format_completed_at(datetime(2026, 5, 16, 0, 35))
+            == "May 16, 2026 at 6:05 AM IST"
         )
 
     def test_format_completed_at_handles_noon_and_midnight(self):
+        # 06:30 UTC + 5:30 = 12:00 IST (noon)
         assert (
-            notif_task._format_completed_at(datetime(2026, 5, 16, 12, 0))
-            == "May 16, 2026 at 12:00 PM"
+            notif_task._format_completed_at(datetime(2026, 5, 16, 6, 30))
+            == "May 16, 2026 at 12:00 PM IST"
         )
+        # 18:35 UTC + 5:30 = 00:05 IST (midnight next day)
         assert (
-            notif_task._format_completed_at(datetime(2026, 5, 16, 0, 5))
-            == "May 16, 2026 at 12:05 AM"
+            notif_task._format_completed_at(datetime(2026, 5, 16, 18, 35))
+            == "May 17, 2026 at 12:05 AM IST"
         )
 
     def test_format_completed_at_returns_empty_for_none(self):
@@ -131,11 +174,12 @@ class TestHelperFunctions:
             payload = notif_task._build_eval_completion_payload(
                 eval_run=eval_run, project_name="ProjX"
             )
+        # 18:33 UTC -> 00:03 IST next day
         assert payload == {
             "run_name": "exp1",
             "project_name": "ProjX",
             "status": "completed",
-            "completed_at": "May 16, 2026 at 6:33 PM",
+            "completed_at": "May 17, 2026 at 12:03 AM IST",
             "link": "http://example.com/evaluations/99",
             "error_message": None,
         }
@@ -181,7 +225,7 @@ class TestSendEvalCompletionNotification:
         project = create_test_project(patched_session)
         run = _make_eval_run(patched_session, project=project)
 
-        with patch.object(notif_task.settings, "emails_enabled", False):
+        with _emails_enabled(False):
             result = notif_task.send_eval_completion_notification.apply(
                 args=[run.id]
             ).result
@@ -197,7 +241,7 @@ class TestSendEvalCompletionNotification:
         project = create_test_project(patched_session)
         run = _make_eval_run(patched_session, project=project)
 
-        with patch.object(notif_task.settings, "emails_enabled", True):
+        with _emails_enabled(True):
             result = notif_task.send_eval_completion_notification.apply(
                 args=[run.id]
             ).result
@@ -219,9 +263,7 @@ class TestSendEvalCompletionNotification:
             )
         patched_session.commit()
 
-        with patch.object(notif_task.settings, "emails_enabled", True), patch.object(
-            notif_task, "send_email"
-        ) as mock_send:
+        with _emails_enabled(True), patch.object(notif_task, "send_email") as mock_send:
             result = notif_task.send_eval_completion_notification.apply(
                 args=[run.id]
             ).result
@@ -252,7 +294,7 @@ class TestSendEvalCompletionNotification:
         )
         patched_session.commit()
 
-        with patch.object(notif_task.settings, "emails_enabled", True), patch.object(
+        with _emails_enabled(True), patch.object(
             notif_task, "send_email", side_effect=RuntimeError("SMTP timeout")
         ):
             result = notif_task.send_eval_completion_notification.apply(
@@ -285,9 +327,7 @@ class TestSendEvalCompletionNotification:
         )
         patched_session.commit()
 
-        with patch.object(notif_task.settings, "emails_enabled", True), patch.object(
-            notif_task, "send_email"
-        ):
+        with _emails_enabled(True), patch.object(notif_task, "send_email"):
             result = notif_task.send_eval_completion_notification.apply(
                 args=[run.id]
             ).result

--- a/backend/app/tests/crud/evaluations/test_completion_trigger.py
+++ b/backend/app/tests/crud/evaluations/test_completion_trigger.py
@@ -1,0 +1,116 @@
+"""Tests for the completion-notification trigger inside update_evaluation_run.
+
+These verify that:
+  - terminal transitions (processing -> completed/failed) enqueue the task
+  - non-transitions (status unchanged, score-only updates) do not
+  - broker errors during enqueue do not bubble up
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.crud.evaluations.core import (
+    TERMINAL_EVAL_STATUSES,
+    update_evaluation_run,
+)
+from app.models import EvaluationRun, EvaluationRunUpdate
+
+
+def _stub_eval_run(status: str = "processing") -> MagicMock:
+    eval_run = MagicMock(spec=EvaluationRun)
+    eval_run.id = 7
+    eval_run.status = status
+    return eval_run
+
+
+class TestTerminalStateTrigger:
+    def test_terminal_set_constants(self):
+        assert TERMINAL_EVAL_STATUSES == {"completed", "failed"}
+
+    def test_transition_to_completed_enqueues(self):
+        eval_run = _stub_eval_run(status="processing")
+        session = MagicMock()
+
+        with patch(
+            "app.crud.evaluations.core._enqueue_eval_completion_notification"
+        ) as enq:
+            update_evaluation_run(
+                session=session,
+                eval_run=eval_run,
+                update=EvaluationRunUpdate(status="completed"),
+            )
+            enq.assert_called_once_with(eval_run)
+
+    def test_transition_to_failed_enqueues(self):
+        eval_run = _stub_eval_run(status="processing")
+        session = MagicMock()
+
+        with patch(
+            "app.crud.evaluations.core._enqueue_eval_completion_notification"
+        ) as enq:
+            update_evaluation_run(
+                session=session,
+                eval_run=eval_run,
+                update=EvaluationRunUpdate(status="failed", error_message="boom"),
+            )
+            enq.assert_called_once_with(eval_run)
+
+    def test_re_set_completed_does_not_re_enqueue(self):
+        """A second update with status=completed on an already-completed row is a no-op."""
+        eval_run = _stub_eval_run(status="completed")
+        session = MagicMock()
+
+        with patch(
+            "app.crud.evaluations.core._enqueue_eval_completion_notification"
+        ) as enq:
+            update_evaluation_run(
+                session=session,
+                eval_run=eval_run,
+                update=EvaluationRunUpdate(status="completed"),
+            )
+            enq.assert_not_called()
+
+    def test_score_only_update_does_not_enqueue(self):
+        """Updates without a status field never trigger a notification."""
+        eval_run = _stub_eval_run(status="completed")
+        session = MagicMock()
+
+        with patch(
+            "app.crud.evaluations.core._enqueue_eval_completion_notification"
+        ) as enq:
+            update_evaluation_run(
+                session=session,
+                eval_run=eval_run,
+                update=EvaluationRunUpdate(score={"foo": 1}),
+            )
+            enq.assert_not_called()
+
+    def test_processing_status_does_not_enqueue(self):
+        """Transition into non-terminal state (e.g. processing) does not notify."""
+        eval_run = _stub_eval_run(status="pending")
+        session = MagicMock()
+
+        with patch(
+            "app.crud.evaluations.core._enqueue_eval_completion_notification"
+        ) as enq:
+            update_evaluation_run(
+                session=session,
+                eval_run=eval_run,
+                update=EvaluationRunUpdate(status="processing"),
+            )
+            enq.assert_not_called()
+
+    def test_enqueue_broker_failure_does_not_raise(self):
+        """If celery .delay() throws, the update still succeeds."""
+        eval_run = _stub_eval_run(status="processing")
+        session = MagicMock()
+
+        with patch(
+            "app.celery.tasks.notifications.send_eval_completion_notification.delay",
+            side_effect=RuntimeError("broker down"),
+        ):
+            # Should NOT raise — the helper swallows broker errors and logs them.
+            update_evaluation_run(
+                session=session,
+                eval_run=eval_run,
+                update=EvaluationRunUpdate(status="completed"),
+            )

--- a/backend/app/tests/crud/test_notification.py
+++ b/backend/app/tests/crud/test_notification.py
@@ -1,0 +1,257 @@
+from sqlmodel import Session
+
+from app.crud.notification import (
+    create_pending_notification,
+    list_pending_notifications_for_entity,
+    mark_notification_failed,
+    mark_notification_sent,
+    notifications_exist_for_entity,
+)
+from app.models import (
+    NotificationEntityType,
+    NotificationProvider,
+    NotificationStatus,
+    NotificationType,
+)
+from app.tests.utils.test_data import create_test_project
+from app.tests.utils.user import create_random_user
+
+
+def _make_pending(
+    db: Session,
+    *,
+    project_id: int | None,
+    recipient_user_id: int,
+    entity_id: int,
+    notification_type: str = NotificationType.EVAL_COMPLETED.value,
+    entity_type: str = NotificationEntityType.EVAL_RUN.value,
+    payload: dict | None = None,
+):
+    return create_pending_notification(
+        session=db,
+        notification_type=notification_type,
+        provider=NotificationProvider.EMAIL.value,
+        recipient_user_id=recipient_user_id,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        project_id=project_id,
+        subject="Test subject",
+        body_template="eval_completion_v1",
+        payload=payload or {"foo": "bar"},
+    )
+
+
+class TestNotificationCRUD:
+    def test_create_pending_persists_with_pending_status(self, db: Session):
+        project = create_test_project(db)
+        user = create_random_user(db)
+
+        notif = _make_pending(
+            db,
+            project_id=project.id,
+            recipient_user_id=user.id,
+            entity_id=42,
+        )
+        db.commit()
+        db.refresh(notif)
+
+        assert notif.id is not None
+        assert notif.status == NotificationStatus.PENDING.value
+        assert notif.sent_at is None
+        assert notif.failed_reason is None
+        assert notif.notification_type == "eval_completed"
+        assert notif.provider == "email"
+        assert notif.project_id == project.id
+        assert notif.payload == {"foo": "bar"}
+
+    def test_create_pending_allows_null_project(self, db: Session):
+        """Magic-link notifications can have project_id=None."""
+        user = create_random_user(db)
+
+        notif = _make_pending(
+            db,
+            project_id=None,
+            recipient_user_id=user.id,
+            entity_id=user.id,
+            notification_type=NotificationType.MAGIC_LINK_LOGIN.value,
+            entity_type=NotificationEntityType.USER.value,
+        )
+        db.commit()
+        db.refresh(notif)
+
+        assert notif.project_id is None
+
+    def test_create_pending_defaults_payload_to_empty(self, db: Session):
+        user = create_random_user(db)
+        project = create_test_project(db)
+
+        notif = create_pending_notification(
+            session=db,
+            notification_type=NotificationType.MAGIC_LINK_LOGIN.value,
+            provider=NotificationProvider.EMAIL.value,
+            recipient_user_id=user.id,
+            entity_type=NotificationEntityType.USER.value,
+            entity_id=user.id,
+            project_id=project.id,
+        )
+        db.commit()
+        db.refresh(notif)
+
+        assert notif.payload == {}
+        assert notif.subject is None
+        assert notif.body_template is None
+
+    def test_notifications_exist_for_entity(self, db: Session):
+        project = create_test_project(db)
+        user = create_random_user(db)
+
+        assert not notifications_exist_for_entity(
+            session=db,
+            entity_type=NotificationEntityType.EVAL_RUN.value,
+            entity_id=99,
+            notification_type=NotificationType.EVAL_COMPLETED.value,
+        )
+
+        _make_pending(
+            db,
+            project_id=project.id,
+            recipient_user_id=user.id,
+            entity_id=99,
+        )
+        db.commit()
+
+        assert notifications_exist_for_entity(
+            session=db,
+            entity_type=NotificationEntityType.EVAL_RUN.value,
+            entity_id=99,
+            notification_type=NotificationType.EVAL_COMPLETED.value,
+        )
+
+    def test_notifications_exist_is_scoped_by_type(self, db: Session):
+        """Existence check is keyed on (entity_type, entity_id, notification_type)."""
+        project = create_test_project(db)
+        user = create_random_user(db)
+
+        _make_pending(
+            db,
+            project_id=project.id,
+            recipient_user_id=user.id,
+            entity_id=7,
+            notification_type=NotificationType.EVAL_COMPLETED.value,
+        )
+        db.commit()
+
+        assert notifications_exist_for_entity(
+            session=db,
+            entity_type=NotificationEntityType.EVAL_RUN.value,
+            entity_id=7,
+            notification_type=NotificationType.EVAL_COMPLETED.value,
+        )
+        # Different notification_type → no match
+        assert not notifications_exist_for_entity(
+            session=db,
+            entity_type=NotificationEntityType.EVAL_RUN.value,
+            entity_id=7,
+            notification_type=NotificationType.EVAL_FAILED.value,
+        )
+
+    def test_mark_notification_sent(self, db: Session):
+        project = create_test_project(db)
+        user = create_random_user(db)
+        notif = _make_pending(
+            db, project_id=project.id, recipient_user_id=user.id, entity_id=11
+        )
+        db.commit()
+        db.refresh(notif)
+
+        mark_notification_sent(session=db, notification=notif)
+        db.commit()
+        db.refresh(notif)
+
+        assert notif.status == NotificationStatus.SENT.value
+        assert notif.sent_at is not None
+        assert notif.failed_reason is None
+
+    def test_mark_notification_failed(self, db: Session):
+        project = create_test_project(db)
+        user = create_random_user(db)
+        notif = _make_pending(
+            db, project_id=project.id, recipient_user_id=user.id, entity_id=12
+        )
+        db.commit()
+        db.refresh(notif)
+
+        mark_notification_failed(
+            session=db, notification=notif, reason="SMTP refused connection"
+        )
+        db.commit()
+        db.refresh(notif)
+
+        assert notif.status == NotificationStatus.FAILED.value
+        assert notif.failed_reason == "SMTP refused connection"
+
+    def test_mark_notification_failed_truncates_long_reason(self, db: Session):
+        """Long failure messages are trimmed to 2000 chars to fit the column."""
+        project = create_test_project(db)
+        user = create_random_user(db)
+        notif = _make_pending(
+            db, project_id=project.id, recipient_user_id=user.id, entity_id=13
+        )
+        db.commit()
+        db.refresh(notif)
+
+        long_reason = "x" * 5000
+        mark_notification_failed(session=db, notification=notif, reason=long_reason)
+        db.commit()
+        db.refresh(notif)
+
+        assert len(notif.failed_reason) == 2000
+
+    def test_mark_notification_failed_handles_empty_reason(self, db: Session):
+        project = create_test_project(db)
+        user = create_random_user(db)
+        notif = _make_pending(
+            db, project_id=project.id, recipient_user_id=user.id, entity_id=14
+        )
+        db.commit()
+        db.refresh(notif)
+
+        mark_notification_failed(session=db, notification=notif, reason="")
+        db.commit()
+        db.refresh(notif)
+
+        assert notif.failed_reason == "Unknown error"
+
+    def test_list_pending_notifications_for_entity_filters_status(self, db: Session):
+        project = create_test_project(db)
+        u1 = create_random_user(db)
+        u2 = create_random_user(db)
+
+        n1 = _make_pending(
+            db, project_id=project.id, recipient_user_id=u1.id, entity_id=21
+        )
+        n2 = _make_pending(
+            db, project_id=project.id, recipient_user_id=u2.id, entity_id=21
+        )
+        db.commit()
+
+        # Both pending initially
+        pending = list_pending_notifications_for_entity(
+            session=db,
+            entity_type=NotificationEntityType.EVAL_RUN.value,
+            entity_id=21,
+            notification_type=NotificationType.EVAL_COMPLETED.value,
+        )
+        assert {n.id for n in pending} == {n1.id, n2.id}
+
+        # Mark one sent; only the still-pending row should be returned
+        mark_notification_sent(session=db, notification=n1)
+        db.commit()
+
+        pending = list_pending_notifications_for_entity(
+            session=db,
+            entity_type=NotificationEntityType.EVAL_RUN.value,
+            entity_id=21,
+            notification_type=NotificationType.EVAL_COMPLETED.value,
+        )
+        assert [n.id for n in pending] == [n2.id]

--- a/backend/app/tests/test_utils.py
+++ b/backend/app/tests/test_utils.py
@@ -16,6 +16,7 @@ from app.utils import (
     APIResponse,
     ValidationErrorDetail,
     download_audio_bytes,
+    generate_eval_completion_email,
     handle_openai_error,
     mask_string,
     require_organization_for_project,
@@ -410,3 +411,50 @@ class TestSendCallbackWithSigning:
         mock_validate.side_effect = ValueError("private IP")
         result = send_callback("https://internal/hook", {"x": 1})
         assert result is False
+
+
+# ---------------------------------------------------------------------------
+# generate_eval_completion_email
+# ---------------------------------------------------------------------------
+class TestGenerateEvalCompletionEmail:
+    def test_completed_renders_expected_fields(self) -> None:
+        data = generate_eval_completion_email(
+            run_name="exp-1",
+            project_name="Demo",
+            status="completed",
+            completed_at="May 16, 2026 at 6:33 PM",
+            link="https://app.example.com/evaluations/",
+            error_message=None,
+        )
+        assert "Completed" in data.subject
+        assert "exp-1" in data.subject
+        assert "Completed" in data.html_content
+        assert "exp-1" in data.html_content
+        assert "Demo" in data.html_content
+        assert "May 16, 2026 at 6:33 PM" in data.html_content
+        assert "https://app.example.com/evaluations/" in data.html_content
+
+    def test_failed_status_changes_label_and_subject(self) -> None:
+        data = generate_eval_completion_email(
+            run_name="exp-1",
+            project_name="Demo",
+            status="failed",
+            completed_at="May 16, 2026 at 6:33 PM",
+            link="https://app.example.com/evaluations/",
+            error_message="Batch failed: timeout",
+        )
+        assert "Failed" in data.subject
+        assert "Failed" in data.html_content
+        assert "Batch failed: timeout" in data.html_content
+
+    def test_no_error_omits_error_block(self) -> None:
+        data = generate_eval_completion_email(
+            run_name="exp-1",
+            project_name="Demo",
+            status="completed",
+            completed_at="May 16, 2026 at 6:33 PM",
+            link="https://app.example.com/evaluations/",
+            error_message=None,
+        )
+        # The error block is only rendered when error_message is truthy
+        assert "Error:" not in data.html_content

--- a/backend/app/tests/test_utils.py
+++ b/backend/app/tests/test_utils.py
@@ -413,9 +413,6 @@ class TestSendCallbackWithSigning:
         assert result is False
 
 
-# ---------------------------------------------------------------------------
-# generate_eval_completion_email
-# ---------------------------------------------------------------------------
 class TestGenerateEvalCompletionEmail:
     def test_completed_renders_expected_fields(self) -> None:
         data = generate_eval_completion_email(

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -211,6 +211,33 @@ def generate_invite_email(
     return EmailData(html_content=html_content, subject=subject)
 
 
+def generate_eval_completion_email(
+    *,
+    run_name: str,
+    project_name: str,
+    status: str,
+    completed_at: str,
+    link: str,
+    error_message: str | None = None,
+) -> EmailData:
+    app_name = settings.PROJECT_NAME
+    status_label = "Completed" if status == "completed" else "Failed"
+    subject = f"{app_name} - Evaluation {status_label}: {run_name}"
+    html_content = render_email_template(
+        template_name="eval_completion.html",
+        context={
+            "app_name": app_name,
+            "run_name": run_name,
+            "project_name": project_name,
+            "status_label": status_label,
+            "completed_at": completed_at,
+            "link": link,
+            "error_message": error_message,
+        },
+    )
+    return EmailData(html_content=html_content, subject=subject)
+
+
 def generate_magic_link_email(*, email_to: str, magic_link_token: str) -> EmailData:
     app_name = settings.PROJECT_NAME
     subject = f"{app_name} - Sign in to your account"


### PR DESCRIPTION
### Issue: https://github.com/ProjectTech4DevAI/kaapi-backend/issues/837

## Summary
- Adds email notifications when an evaluation run `completes` or `fails`. 
- Introduces a generic notification table (provider-agnostic), a Celery task that emails all project members on terminal status with idempotency checks.
- Whenever a notification is sent, a corresponding entry should also be created in the notifications table:
   - When a user is invited to any project
   - When a user logs in via a magic link

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add end-to-end notification system to track outbound emails (pending/sent/failed) and record delivery outcomes.
  * Automatic evaluation-completion emails sent to active project members when runs finish.
  * Invite and magic-link emails now persist delivery records so send results are tracked.

* **Improvements**
  * Updated email templates with refreshed styling and pill-shaped action buttons.

* **Tests**
  * Added tests covering notification creation, delivery outcomes, and completion-notification behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ProjectTech4DevAI/kaapi-backend/pull/847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->