### PR TITLE
Revert "Config: remove version id from response body"

### DIFF
--- a/backend/app/models/config/version.py
+++ b/backend/app/models/config/version.py
@@ -117,6 +117,7 @@ class ConfigVersionUpdate(SQLModel):
 
 
 class ConfigVersionPublic(ConfigVersionBase):
+    id: UUID = Field(description="Unique id for the configuration version")
     config_id: UUID = Field(description="Id of the parent configuration")
     version: int = Field(nullable=False, description="Version number starting at 1")
     inserted_at: datetime


### PR DESCRIPTION
Reverts ProjectTech4DevAI/kaapi-backend#822.

### Changes
- Config ID is required in the response. Reverting https://github.com/ProjectTech4DevAI/kaapi-backend/pull/822 that removed `id` from the model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration version responses now explicitly include the unique identifier field. The version ID is now part of the public data structure returned by configuration version endpoints, making the identifier accessible in all API operations related to configuration version management and data exports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ProjectTech4DevAI/kaapi-backend/pull/863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->