### PR TITLE
LLMOutput Fix: generate presigned URL for audio output in LLM call response

### DIFF
--- a/backend/app/api/routes/llm.py
+++ b/backend/app/api/routes/llm.py
@@ -6,6 +6,7 @@ from opentelemetry import trace
 
 from app.api.deps import AuthContextDep, SessionDep
 from app.api.permissions import Permission, require_permission
+from app.core.cloud.storage import get_cloud_storage
 from app.core.telemetry import log_context
 from app.crud.jobs import JobCrud
 from app.crud.llm import get_llm_calls_by_job_id
@@ -150,13 +151,32 @@ def get_llm_call_status(
                 # Get the first LLM call from the list which will be the only call for the job id
                 # since we initially won't be using this endpoint for llm chains
                 llm_call = llm_calls[0]
+                output_payload = llm_call.content
+                if (
+                    isinstance(output_payload, dict)
+                    and output_payload.get("type") == "audio"
+                    and isinstance(output_payload.get("content"), dict)
+                    and output_payload["content"].get("format") == "uri"
+                ):
+                    s3_path = output_payload["content"].get("value", "")
+                    try:
+                        storage = get_cloud_storage(session, project_id)
+                        output_payload["content"]["value"] = storage.get_signed_url(
+                            s3_path, expires_in=3600
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            f"[get_llm_call] Failed to generate presigned URL for audio: {e} | job_id={job_id}"
+                        )
+                        output_payload["content"]["value"] = ""
+                    output_payload["content"]["format"] = "url"
 
                 llm_response = LLMResponse(
                     provider_response_id=llm_call.provider_response_id or "",
                     conversation_id=llm_call.conversation_id,
                     provider=llm_call.provider,
                     model=llm_call.model,
-                    output=llm_call.content,
+                    output=output_payload,
                 )
 
                 usage_payload = llm_call.usage

--- a/backend/app/api/routes/llm.py
+++ b/backend/app/api/routes/llm.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 from uuid import UUID
 
@@ -151,7 +152,7 @@ def get_llm_call_status(
                 # Get the first LLM call from the list which will be the only call for the job id
                 # since we initially won't be using this endpoint for llm chains
                 llm_call = llm_calls[0]
-                output_payload = llm_call.content
+                output_payload = copy.deepcopy(llm_call.content)
                 if (
                     isinstance(output_payload, dict)
                     and output_payload.get("type") == "audio"
@@ -166,7 +167,7 @@ def get_llm_call_status(
                         )
                     except Exception as e:
                         logger.warning(
-                            f"[get_llm_call] Failed to generate presigned URL for audio: {e} | job_id={job_id}"
+                            f"[get_llm_call_status] Failed to generate presigned URL for audio: {e} | job_id={job_id}"
                         )
                         output_payload["content"]["value"] = ""
                     output_payload["content"]["format"] = "url"
@@ -182,7 +183,7 @@ def get_llm_call_status(
                 usage_payload = llm_call.usage
                 if not usage_payload:
                     logger.warning(
-                        f"[get_llm_call] Missing usage data for llm_call job_id={job_id}, project_id={project_id}"
+                        f"[get_llm_call_status] Missing usage data for llm_call job_id={job_id}, project_id={project_id}"
                     )
                     usage_payload = {
                         "input_tokens": 0,

--- a/backend/app/tests/api/routes/test_llm.py
+++ b/backend/app/tests/api/routes/test_llm.py
@@ -17,7 +17,11 @@ from app.models.llm.request import (
 )
 from app.models.llm import LLMCallRequest
 from app.tests.utils.auth import TestAuthContext
-from app.tests.utils.llm import create_llm_job, create_llm_call_with_response
+from app.tests.utils.llm import (
+    create_llm_job,
+    create_llm_call_with_response,
+    create_llm_call_with_audio_uri_response,
+)
 
 
 @pytest.fixture
@@ -357,3 +361,70 @@ def test_get_llm_call_not_found(
     )
 
     assert response.status_code == 404
+
+
+@pytest.fixture
+def llm_audio_uri_job(db: Session, user_api_key: TestAuthContext) -> Job:
+    job = create_llm_job(db)
+    create_llm_call_with_audio_uri_response(
+        db,
+        job_id=job.id,
+        project_id=user_api_key.project_id,
+        organization_id=user_api_key.organization_id,
+    )
+    return job
+
+
+def test_get_llm_call_audio_uri_swapped_to_presigned_url(
+    client: TestClient,
+    db: Session,
+    user_api_key_header: dict[str, str],
+    llm_audio_uri_job: Job,
+) -> None:
+    """Audio content stored with format='uri' is served as format='url' with a presigned URL."""
+    presigned = (
+        "https://s3.amazonaws.com/kaapi-bucket/audio/output.wav?X-Amz-Signature=abc"
+    )
+    JobCrud(db).update(llm_audio_uri_job.id, JobUpdate(status=JobStatus.SUCCESS))
+
+    with patch("app.api.routes.llm.get_cloud_storage") as mock_storage:
+        mock_storage.return_value.get_signed_url.return_value = presigned
+
+        response = client.get(
+            f"/api/v1/llm/call/{llm_audio_uri_job.id}",
+            headers=user_api_key_header,
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is True
+    audio = body["data"]["llm_response"]["response"]["output"]["content"]
+    assert audio["format"] == "url"
+    assert audio["value"] == presigned
+
+
+def test_get_llm_call_audio_uri_presigned_failure_returns_empty_value(
+    client: TestClient,
+    db: Session,
+    user_api_key_header: dict[str, str],
+    llm_audio_uri_job: Job,
+) -> None:
+    """When presigned URL generation fails, format is still 'url' and value is empty string."""
+    JobCrud(db).update(llm_audio_uri_job.id, JobUpdate(status=JobStatus.SUCCESS))
+
+    with patch("app.api.routes.llm.get_cloud_storage") as mock_storage:
+        mock_storage.return_value.get_signed_url.side_effect = Exception(
+            "S3 unavailable"
+        )
+
+        response = client.get(
+            f"/api/v1/llm/call/{llm_audio_uri_job.id}",
+            headers=user_api_key_header,
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is True
+    audio = body["data"]["llm_response"]["response"]["output"]["content"]
+    assert audio["format"] == "url"
+    assert audio["value"] == ""

--- a/backend/app/tests/utils/llm.py
+++ b/backend/app/tests/utils/llm.py
@@ -73,3 +73,64 @@ def create_llm_call_with_response(
     )
 
     return llm_call
+
+
+def create_llm_call_with_audio_uri_response(
+    db: Session,
+    job_id,
+    project_id: int,
+    organization_id: int,
+    s3_path: str = "s3://bucket/audio/output.wav",
+) -> LLMCallResponse:
+    """
+    Create a persisted LlmCall with audio content stored as an S3 URI.
+
+    Simulates the TTS path where audio is uploaded to S3 and stored with
+    format='uri' (internal format, must be swapped to presigned URL on read).
+    """
+    config_blob = ConfigBlob(
+        completion=KaapiCompletionConfig(
+            provider="openai",
+            params={
+                "model": "tts-1",
+                "instructions": "Speak clearly.",
+                "temperature": 0.7,
+            },
+            type="text",
+        )
+    )
+
+    llm_call = create_llm_call(
+        db,
+        request=LLMCallRequest(
+            query=QueryParams(input="Say hello"),
+            config=LLMCallConfig(blob=config_blob),
+        ),
+        job_id=job_id,
+        project_id=project_id,
+        organization_id=organization_id,
+        resolved_config=config_blob,
+        original_provider="openai",
+    )
+
+    update_llm_call_response(
+        db,
+        llm_call_id=llm_call.id,
+        provider_response_id="resp_tts_xyz",
+        content={
+            "type": "audio",
+            "content": {
+                "format": "uri",
+                "value": s3_path,
+                "mime_type": "audio/wav",
+            },
+        },
+        usage={
+            "input_tokens": 5,
+            "output_tokens": 0,
+            "total_tokens": 5,
+            "reasoning_tokens": None,
+        },
+    )
+
+    return llm_call

--- a/backend/app/tests/utils/llm.py
+++ b/backend/app/tests/utils/llm.py
@@ -92,8 +92,8 @@ def create_llm_call_with_audio_uri_response(
         completion=KaapiCompletionConfig(
             provider="openai",
             params={
-                "model": "tts-1",
-                "instructions": "Speak clearly.",
+                "model": "gpt-4o",
+                "instructions": "You are helpful.",
                 "temperature": 0.7,
             },
             type="text",


### PR DESCRIPTION
ISSUE: #866 

## Summary
GET `/llm/call/{job_id}` was broken for all audio (TTS) jobs. When audio is uploaded to S3 during job execution, jobs.py stores format: "uri" in the DB as an internal marker for "this is an S3 path, generate a presigned URL before serving." The AudioContent pydantic model (used in LLMResponse) only accepts "base64" or "url", so deserialization always failed with a validation error.
 
#### Fix:
`llm_call.content is dict[str, Any] (raw JSONB from DB)`. Pydantic hasn't parsed it yet, and parsing is exactly what fails when `format == "uri"`. The fix must happen on the raw dict before the model is constructed.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.
