### PR TITLE
Deployment: Stop automate deployment in ECS

### DIFF
--- a/.github/workflows/cd-staging-ecs.yml
+++ b/.github/workflows/cd-staging-ecs.yml
@@ -1,9 +1,7 @@
-name: Deploy Kaapi to ECS
+name: Deploy Kaapi to ECS Staging
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Stop automate deployment in ECS after merging the PR into `main`, because now we are using the EC2 instance for staging instead of ECS.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified staging deployment workflow configuration to require manual triggering instead of automatic deployment on branch updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ProjectTech4DevAI/kaapi-backend/pull/876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->