### PR TITLE
fix(cron): add pending-jobs check to cron

### DIFF
--- a/scripts/python/invoke-cron.py
+++ b/scripts/python/invoke-cron.py
@@ -144,7 +144,9 @@ class EndpointInvoker:
             while True:
                 try:
                     start_time = datetime.now()
-                    logger.info(f"Invoking {len(self.endpoints)} endpoints at {start_time}")
+                    logger.info(
+                        f"Invoking {len(self.endpoints)} endpoints at {start_time}"
+                    )
 
                     for endpoint in self.endpoints:
                         try:

--- a/scripts/python/invoke-cron.py
+++ b/scripts/python/invoke-cron.py
@@ -15,7 +15,10 @@ import httpx
 from dotenv import load_dotenv
 
 # Configuration
-ENDPOINT = "/api/v1/cron/evaluations"  # Endpoint to invoke
+ENDPOINTS = [
+    "/api/v1/cron/evaluations",
+    "/api/v1/cron/pending-jobs",
+]
 REQUEST_TIMEOUT = 30  # Timeout for requests in seconds
 
 # Setup logging
@@ -33,7 +36,7 @@ class EndpointInvoker:
         # Load BASE_URL from environment with default fallback
         base_url = os.getenv("API_BASE_URL", "http://localhost:8000")
         self.base_url = base_url.rstrip("/")
-        self.endpoint = ENDPOINT
+        self.endpoints = ENDPOINTS
 
         # Load interval from environment with default of 5 minutes
         self.interval_minutes = int(os.getenv("CRON_INTERVAL_MINUTES", "5"))
@@ -83,25 +86,23 @@ class EndpointInvoker:
             logger.error(f"Authentication error: {e}")
             raise
 
-    async def invoke_endpoint(self, client: httpx.AsyncClient) -> dict:
-        """Invoke the configured endpoint."""
+    async def invoke_endpoint(self, client: httpx.AsyncClient, endpoint: str) -> dict:
+        """Invoke a single endpoint."""
         if not self.access_token:
             await self.authenticate(client)
 
         headers = {"Authorization": f"Bearer {self.access_token}"}
 
-        # Debug: Log what we're sending
-        logger.debug(f"Request URL: {self.base_url}{self.endpoint}")
+        logger.debug(f"Request URL: {self.base_url}{endpoint}")
         logger.debug(f"Request headers: {headers}")
 
         try:
             response = await client.get(
-                f"{self.base_url}{self.endpoint}",
+                f"{self.base_url}{endpoint}",
                 headers=headers,
                 timeout=REQUEST_TIMEOUT,
             )
 
-            # Debug: Log response headers and first part of body
             logger.debug(f"Response status: {response.status_code}")
             logger.debug(f"Response headers: {dict(response.headers)}")
 
@@ -111,7 +112,7 @@ class EndpointInvoker:
                 await self.authenticate(client)
                 headers = {"Authorization": f"Bearer {self.access_token}"}
                 response = await client.get(
-                    f"{self.base_url}{self.endpoint}",
+                    f"{self.base_url}{endpoint}",
                     headers=headers,
                     timeout=REQUEST_TIMEOUT,
                 )
@@ -132,7 +133,7 @@ class EndpointInvoker:
         """Main loop to invoke endpoint periodically."""
         logger.info(f"Using API Base URL: {self.base_url}")
         logger.info(
-            f"Starting cron job - invoking {self.endpoint} every {self.interval_minutes} minutes"
+            f"Starting cron job - invoking {self.endpoints} every {self.interval_minutes} minutes"
         )
 
         # Use async context manager to ensure proper cleanup
@@ -145,8 +146,9 @@ class EndpointInvoker:
                     start_time = datetime.now()
                     logger.info(f"Invoking endpoint at {start_time}")
 
-                    result = await self.invoke_endpoint(client)
-                    logger.info(f"Endpoint invoked successfully: {result}")
+                    for endpoint in self.endpoints:
+                        result = await self.invoke_endpoint(client, endpoint)
+                        logger.info(f"[{endpoint}] invoked successfully: {result}")
 
                     # Calculate next invocation time
                     elapsed = (datetime.now() - start_time).total_seconds()

--- a/scripts/python/invoke-cron.py
+++ b/scripts/python/invoke-cron.py
@@ -93,8 +93,7 @@ class EndpointInvoker:
 
         headers = {"Authorization": f"Bearer {self.access_token}"}
 
-        logger.debug(f"Request URL: {self.base_url}{endpoint}")
-        logger.debug(f"Request headers: {headers}")
+        logger.debug(f"[invoke_endpoint] Request URL: {self.base_url}{endpoint}")
 
         try:
             response = await client.get(
@@ -103,12 +102,13 @@ class EndpointInvoker:
                 timeout=REQUEST_TIMEOUT,
             )
 
-            logger.debug(f"Response status: {response.status_code}")
-            logger.debug(f"Response headers: {dict(response.headers)}")
+            logger.debug(f"[invoke_endpoint] Response status: {response.status_code}")
 
             # If unauthorized or forbidden (token expired/invalid), re-authenticate and retry once
             if response.status_code in (401, 403):
-                logger.info("Token expired or invalid, re-authenticating...")
+                logger.info(
+                    "[invoke_endpoint] Token expired or invalid, re-authenticating..."
+                )
                 await self.authenticate(client)
                 headers = {"Authorization": f"Bearer {self.access_token}"}
                 response = await client.get(
@@ -122,11 +122,11 @@ class EndpointInvoker:
 
         except httpx.HTTPStatusError as e:
             logger.error(
-                f"Endpoint invocation failed with status {e.response.status_code}: {e.response.text}"
+                f"[invoke_endpoint] Endpoint invocation failed with status {e.response.status_code}: {e.response.text}"
             )
             raise
         except Exception as e:
-            logger.error(f"Endpoint invocation error: {e}")
+            logger.error(f"[invoke_endpoint] Endpoint invocation error: {e}")
             raise
 
     async def run(self):
@@ -147,8 +147,13 @@ class EndpointInvoker:
                     logger.info(f"Invoking endpoint at {start_time}")
 
                     for endpoint in self.endpoints:
-                        result = await self.invoke_endpoint(client, endpoint)
-                        logger.info(f"[{endpoint}] invoked successfully: {result}")
+                        try:
+                            result = await self.invoke_endpoint(client, endpoint)
+                            logger.info(f"[{endpoint}] invoked successfully: {result}")
+                        except Exception as endpoint_error:
+                            logger.error(
+                                f"[{endpoint}] invocation failed: {endpoint_error}"
+                            )
 
                     # Calculate next invocation time
                     elapsed = (datetime.now() - start_time).total_seconds()

--- a/scripts/python/invoke-cron.py
+++ b/scripts/python/invoke-cron.py
@@ -144,7 +144,7 @@ class EndpointInvoker:
             while True:
                 try:
                     start_time = datetime.now()
-                    logger.info(f"Invoking endpoint at {start_time}")
+                    logger.info(f"Invoking {len(self.endpoints)} endpoints at {start_time}")
 
                     for endpoint in self.endpoints:
                         try:


### PR DESCRIPTION
### Target issue is #881 

## Summary

In the previous PR that added pending job monitoring, the invoke-cron.py script was modified locally but the changes were never pushed/included in the PR. The server-side implementation existed, but since the updated script wasn't shipped, the cron script was never calling /api/v1/cron/pending-jobs — so pending job monitoring was never actually running. This PR ships that missing change.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cron scheduler now supports invoking multiple API endpoints in sequence, enabling more comprehensive background job processing.

* **Improvements**
  * Enhanced error handling with per-endpoint authentication retry on authorization failures.
  * Improved logging with detailed endpoint-specific success/failure reporting for better monitoring visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ProjectTech4DevAI/kaapi-backend/pull/882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->