### PR TITLE
hotfix: reset model_config sequence before seeding in migration 063

### DIFF
--- a/backend/app/alembic/versions/063_seed_stt_tts_model_configs.py
+++ b/backend/app/alembic/versions/063_seed_stt_tts_model_configs.py
@@ -78,7 +78,10 @@ def upgrade():
         "CREATE INDEX ix_model_config_output_modalities ON global.model_config USING gin (output_modalities)"
     )
 
-    # 6. Seed rows — pricing per 1M tokens (USD): response/batch = text i/o; audio = audio-modal i/o
+    op.execute(
+        "SELECT setval(pg_get_serial_sequence('global.model_config', 'id'), MAX(id)) FROM global.model_config"
+    )
+
     op.execute(
         """
         INSERT INTO global.model_config


### PR DESCRIPTION
### Target issue is #884 

## Summary
Fixes #884. Migration 063 failed on staging because the model_config id sequence was behind the actual max id in the DB. Auto-generated ids during the INSERT collided with existing rows, causing UniqueViolation on model_config_pkey. Fix resets the sequence to max(id) before seeding so new rows get non-conflicting ids.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.