### PR TITLE
Model Config: relax model validation to warning

### DIFF
--- a/backend/app/crud/model_config.py
+++ b/backend/app/crud/model_config.py
@@ -124,7 +124,7 @@ def validate_blob_model_or_raise(session: Session, blob: ConfigBlob) -> None:
     )
     if model_row is None:
         logger.warning(
-            f"[validate_blob_model_or_raise] Model '{model_name}' not found for provider='{provider}'. Proceeding without validation."
+            f"[validate_blob_model_or_raise] Model '{model_name}' not found for provider='{provider}'."
         )
 
     if completion_type == "tts" and model_row is not None:
@@ -140,7 +140,7 @@ def validate_blob_model_or_raise(session: Session, blob: ConfigBlob) -> None:
         if voice and allowed_voices and voice not in allowed_voices:
             logger.warning(
                 f"[validate_blob_model_or_raise] Voice '{voice}' is not supported for provider='{provider}' "
-                f"model='{model_name}'. Allowed: {allowed_voices}. Proceeding anyway."
+                f"model='{model_name}'. Allowed: {allowed_voices}."
             )
 
 

--- a/backend/app/crud/model_config.py
+++ b/backend/app/crud/model_config.py
@@ -125,6 +125,7 @@ def validate_blob_model_or_raise(session: Session, blob: ConfigBlob) -> None:
     if model_row is None:
         logger.warning(
             f"[validate_blob_model_or_raise] Model '{model_name}' not found for provider='{provider}'."
+            "Kaapi does not yet support this model, but will forward as long as the `model` field has no typos and the model is not deprecated by the provider"
         )
 
     if completion_type == "tts" and model_row is not None:

--- a/backend/app/crud/model_config.py
+++ b/backend/app/crud/model_config.py
@@ -1,7 +1,10 @@
+import logging
 from typing import Any, Literal
 
 from fastapi import HTTPException
 from sqlmodel import Session, select
+
+logger = logging.getLogger(__name__)
 
 from app.models import ModelConfig
 from app.models.llm.request import ConfigBlob
@@ -120,31 +123,11 @@ def validate_blob_model_or_raise(session: Session, blob: ConfigBlob) -> None:
         model_name=model_name,
     )
     if model_row is None:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Model '{model_name}' not found for provider='{provider}'.",
+        logger.warning(
+            f"[validate_blob_model_or_raise] Model '{model_name}' not found for provider='{provider}'. Proceeding without validation."
         )
 
-    if not is_model_supported(
-        session=session,
-        provider=provider,  # type: ignore[arg-type]
-        completion_type=completion_type,
-        model_name=model_name,
-    ):
-        allowed = list_supported_models(
-            session=session,
-            provider=provider,  # type: ignore[arg-type]
-            completion_type=completion_type,
-        )
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"Model '{model_name}' is not supported for provider='{provider}' "
-                f"type='{completion_type}'. Allowed: {allowed}"
-            ),
-        )
-
-    if completion_type == "tts":
+    if completion_type == "tts" and model_row is not None:
         voice = (completion.params or {}).get("voice")
         voice_spec = (
             model_row.config.get("voice")
@@ -155,12 +138,9 @@ def validate_blob_model_or_raise(session: Session, blob: ConfigBlob) -> None:
             voice_spec.get("options") if isinstance(voice_spec, dict) else None
         )
         if voice and allowed_voices and voice not in allowed_voices:
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    f"Voice '{voice}' is not supported for provider='{provider}' "
-                    f"model='{model_name}'. Allowed: {allowed_voices}"
-                ),
+            logger.warning(
+                f"[validate_blob_model_or_raise] Voice '{voice}' is not supported for provider='{provider}' "
+                f"model='{model_name}'. Allowed: {allowed_voices}. Proceeding anyway."
             )
 
 

--- a/backend/app/tests/crud/test_model_config.py
+++ b/backend/app/tests/crud/test_model_config.py
@@ -227,22 +227,23 @@ def test_validate_blob_missing_model_raises(monkeypatch: pytest.MonkeyPatch) -> 
     assert "model is required" in exc.value.detail
 
 
-def test_validate_blob_model_not_found_raises(
+def test_validate_blob_model_not_found_warns_and_continues(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Model that doesn't exist in model_config raises 400 with model name in detail."""
+    """Missing model logs a warning and lets the request proceed."""
     _patch_validators(monkeypatch, row=None, supported=False)
     blob = _make_blob("openai", "text", {"model": "gpt-4-turbo"})
-    with pytest.raises(HTTPException) as exc:
+    with caplog.at_level("WARNING"):
         model_config_crud.validate_blob_model_or_raise(session=None, blob=blob)  # type: ignore[arg-type]
-    assert exc.value.status_code == 400
-    assert "gpt-4-turbo" in exc.value.detail
+    assert "gpt-4-turbo" in caplog.text
+    assert "not found" in caplog.text
 
 
-def test_validate_blob_wrong_type_for_model_raises(
+def test_validate_blob_wrong_type_for_model_passes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Model that exists but is wrong type (e.g. TTS model used as text) raises 400 with allowed list."""
+    """Wrong completion type no longer validated — request proceeds silently."""
     row = SimpleNamespace(config={})
     _patch_validators(
         monkeypatch,
@@ -251,11 +252,7 @@ def test_validate_blob_wrong_type_for_model_raises(
         allowed=["gpt-4o", "gpt-4o-mini"],
     )
     blob = _make_blob("openai", "text", {"model": "some-audio-model"})
-    with pytest.raises(HTTPException) as exc:
-        model_config_crud.validate_blob_model_or_raise(session=None, blob=blob)  # type: ignore[arg-type]
-    assert exc.value.status_code == 400
-    assert "some-audio-model" in exc.value.detail
-    assert "gpt-4o" in exc.value.detail
+    model_config_crud.validate_blob_model_or_raise(session=None, blob=blob)  # type: ignore[arg-type]
 
 
 def test_validate_blob_supported_text_passes(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -265,9 +262,11 @@ def test_validate_blob_supported_text_passes(monkeypatch: pytest.MonkeyPatch) ->
     model_config_crud.validate_blob_model_or_raise(session=None, blob=blob)  # type: ignore[arg-type]
 
 
-def test_validate_blob_tts_invalid_voice_raises(
+def test_validate_blob_tts_invalid_voice_warns(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
+    """Invalid TTS voice logs a warning but does not raise."""
     row = SimpleNamespace(
         config={"voice": {"type": "enum", "options": ["Kore", "Orus"]}}
     )
@@ -277,11 +276,10 @@ def test_validate_blob_tts_invalid_voice_raises(
         "tts",
         {"model": "gemini-2.5-flash-preview-tts", "voice": "Sarah"},
     )
-    with pytest.raises(HTTPException) as exc:
+    with caplog.at_level("WARNING"):
         model_config_crud.validate_blob_model_or_raise(session=None, blob=blob)  # type: ignore[arg-type]
-    assert exc.value.status_code == 400
-    assert "Sarah" in exc.value.detail
-    assert "Kore" in exc.value.detail
+    assert "Sarah" in caplog.text
+    assert "Kore" in caplog.text
 
 
 def test_validate_blob_tts_valid_voice_passes(
@@ -309,26 +307,19 @@ def test_validate_blob_tts_no_voice_spec_passes(
     model_config_crud.validate_blob_model_or_raise(session=None, blob=blob)  # type: ignore[arg-type]
 
 
-def test_validate_blob_stt_model_rejected_for_text_type(
+def test_validate_blob_stt_model_passes_for_text_type(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """STT-only model (audio input) must be rejected when type=text.
-
-    Regression: previously only stt/tts triggered is_model_supported; type=text
-    only checked model existence, so gemini-2.5-pro (STT) passed as a text model.
-    """
+    """Completion-type mismatch no longer enforced — STT model passes for type=text."""
     row = SimpleNamespace(config={})
     _patch_validators(
         monkeypatch,
         row=row,
-        supported=False,  # modality filter excludes AUDIO-input models for type=text
+        supported=False,
         allowed=["gpt-4o", "gpt-4o-mini"],
     )
     blob = _make_blob("google", "text", {"model": "gemini-2.5-pro"})
-    with pytest.raises(HTTPException) as exc:
-        model_config_crud.validate_blob_model_or_raise(session=None, blob=blob)  # type: ignore[arg-type]
-    assert exc.value.status_code == 400
-    assert "gemini-2.5-pro" in exc.value.detail
+    model_config_crud.validate_blob_model_or_raise(session=None, blob=blob)  # type: ignore[arg-type]
 
 
 def test_validate_blob_text_model_accepted_for_text_type(


### PR DESCRIPTION
### Target issue is #901 

## Summary

`validate_blob_model_or_raise` no longer blocks requests when a model is missing from `model_config` or has a mismatched completion type. It logs a warning and lets the call through. Provider API stays the source of truth; `model_config` is now metadata, not a gatekeeper.

**What changed**
- Model not found → `logger.warning`, continue.
- Wrong completion type check removed entirely (no warning, no validation).
- TTS voice check guarded against `None` model_row.
- Missing `model` param still returns `400`.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Model configuration validation improved to handle missing or unsupported models more gracefully, logging warnings instead of blocking operations and preventing continued processing.
- TTS voice validation enhanced to accept unsupported voices while logging warnings for monitoring and tracking purposes.
- STT model handling improved to properly support text-based completion types and related configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->