### PR TITLE
Evaluation: Category-wise analytics for Evals

### DIFF
--- a/backend/app/crud/evaluations/core.py
+++ b/backend/app/crud/evaluations/core.py
@@ -17,6 +17,7 @@ from app.models.config.config import ConfigTag
 from app.models.llm.request import ConfigBlob, LLMCallConfig
 from app.models.stt_evaluation import EvaluationType
 from app.services.llm.jobs import resolve_config_blob
+from app.services.evaluations.validators import DEFAULT_CATEGORY
 
 logger = logging.getLogger(__name__)
 
@@ -480,7 +481,7 @@ def group_traces_by_question_id(
                 "question_id": question_id,
                 "question": first.get("question", ""),
                 "ground_truth_answer": first.get("ground_truth_answer", ""),
-                "category": first.get("category") or "Other",
+                "category": first.get("category") or DEFAULT_CATEGORY,
                 "llm_answers": [t.get("llm_answer", "") for t in group_traces],
                 "trace_ids": [t.get("trace_id", "") for t in group_traces],
                 "scores": [t.get("scores", []) for t in group_traces],

--- a/backend/app/crud/evaluations/core.py
+++ b/backend/app/crud/evaluations/core.py
@@ -11,13 +11,12 @@ from app.core.storage_utils import upload_jsonl_to_object_store
 from app.core.util import now
 from app.crud.config.version import ConfigVersionCrud
 from app.crud.evaluations.langfuse import fetch_trace_scores_from_langfuse
-from app.crud.evaluations.score import EvaluationScore
+from app.crud.evaluations.score import DEFAULT_CATEGORY, EvaluationScore
 from app.models import EvaluationRun, EvaluationRunUpdate
 from app.models.config.config import ConfigTag
 from app.models.llm.request import ConfigBlob, LLMCallConfig
 from app.models.stt_evaluation import EvaluationType
 from app.services.llm.jobs import resolve_config_blob
-from app.services.evaluations.validators import DEFAULT_CATEGORY
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/crud/evaluations/core.py
+++ b/backend/app/crud/evaluations/core.py
@@ -448,6 +448,7 @@ def group_traces_by_question_id(
                 "question_id": 1,
                 "question": "What is Python?",
                 "ground_truth_answer": "...",
+                "category": "health",
                 "llm_answers": ["Answer 1", "Answer 2"],
                 "trace_ids": ["trace-1", "trace-2"],
                 "scores": [[...], [...]]
@@ -478,6 +479,7 @@ def group_traces_by_question_id(
                 "question_id": question_id,
                 "question": first.get("question", ""),
                 "ground_truth_answer": first.get("ground_truth_answer", ""),
+                "category": first.get("category") or "Other",
                 "llm_answers": [t.get("llm_answer", "") for t in group_traces],
                 "trace_ids": [t.get("trace_id", "") for t in group_traces],
                 "scores": [t.get("scores", []) for t in group_traces],

--- a/backend/app/crud/evaluations/langfuse.py
+++ b/backend/app/crud/evaluations/langfuse.py
@@ -109,6 +109,12 @@ def create_langfuse_dataset_run(
                     if question_id:
                         metadata["question_id"] = question_id
 
+                    item_metadata = getattr(dataset_item, "metadata", None)
+                    if isinstance(item_metadata, dict):
+                        item_category = item_metadata.get("category")
+                        if item_category:
+                            metadata["category"] = item_category
+
                     # Create trace with basic info
                     langfuse.trace(
                         id=trace_id,
@@ -255,6 +261,7 @@ def upload_dataset_to_langfuse(
 
     def upload_item(item: dict[str, str], duplicate_num: int, question_id: str) -> bool:
         try:
+            category = item.get("category") or "Other"
             langfuse.create_dataset_item(
                 dataset_name=dataset_name,
                 input={"question": item["question"]},
@@ -264,6 +271,7 @@ def upload_dataset_to_langfuse(
                     "duplicate_number": duplicate_num + 1,
                     "duplication_factor": duplication_factor,
                     "question_id": question_id,
+                    "category": category,
                 },
             )
             return True
@@ -429,6 +437,7 @@ def fetch_trace_scores_from_langfuse(
                 "llm_answer": "",
                 "ground_truth_answer": "",
                 "question_id": "",
+                "category": "Other",
                 "scores": [],
             }
 
@@ -446,12 +455,15 @@ def fetch_trace_scores_from_langfuse(
                 elif isinstance(trace.output, str):
                     trace_data["llm_answer"] = trace.output
 
-            # Get ground truth and question_id from metadata
+            # Get ground truth, question_id, and category from metadata.
+            # `category` is absent on traces produced before the feature
+            # existed, so default to "Other" for backwards compatibility.
             if trace.metadata and isinstance(trace.metadata, dict):
                 trace_data["ground_truth_answer"] = trace.metadata.get(
                     "ground_truth", ""
                 )
                 trace_data["question_id"] = trace.metadata.get("question_id", "")
+                trace_data["category"] = trace.metadata.get("category") or "Other"
 
             # Add scores from this trace
             if trace.scores:

--- a/backend/app/crud/evaluations/langfuse.py
+++ b/backend/app/crud/evaluations/langfuse.py
@@ -463,7 +463,10 @@ def fetch_trace_scores_from_langfuse(
                     "ground_truth", ""
                 )
                 trace_data["question_id"] = trace.metadata.get("question_id", "")
-                trace_data["category"] = trace.metadata.get("category") or "Other"
+                raw_category = trace.metadata.get("category") or ""
+                trace_data["category"] = (
+                    raw_category.title() if raw_category else "Other"
+                )
 
             # Add scores from this trace
             if trace.scores:

--- a/backend/app/crud/evaluations/langfuse.py
+++ b/backend/app/crud/evaluations/langfuse.py
@@ -16,6 +16,7 @@ from langfuse import Langfuse
 
 from app.crud.evaluations.merge import compute_summary_scores
 from app.crud.evaluations.score import EvaluationScore, TraceData, TraceScore
+from app.services.evaluations.validators import DEFAULT_CATEGORY
 
 logger = logging.getLogger(__name__)
 
@@ -261,7 +262,7 @@ def upload_dataset_to_langfuse(
 
     def upload_item(item: dict[str, str], duplicate_num: int, question_id: str) -> bool:
         try:
-            category = item.get("category") or "Other"
+            category = item.get("category") or DEFAULT_CATEGORY
             langfuse.create_dataset_item(
                 dataset_name=dataset_name,
                 input={"question": item["question"]},
@@ -439,7 +440,7 @@ def fetch_trace_scores_from_langfuse(
                 "llm_answer": "",
                 "ground_truth_answer": "",
                 "question_id": "",
-                "category": "Other",
+                "category": DEFAULT_CATEGORY,
                 "scores": [],
             }
 
@@ -467,7 +468,7 @@ def fetch_trace_scores_from_langfuse(
                 trace_data["question_id"] = trace.metadata.get("question_id", "")
                 raw_category = trace.metadata.get("category") or ""
                 trace_data["category"] = (
-                    raw_category.title() if raw_category else "Other"
+                    raw_category.title() if raw_category else DEFAULT_CATEGORY
                 )
 
             # Add scores from this trace

--- a/backend/app/crud/evaluations/langfuse.py
+++ b/backend/app/crud/evaluations/langfuse.py
@@ -15,8 +15,12 @@ from typing import Any
 from langfuse import Langfuse
 
 from app.crud.evaluations.merge import compute_summary_scores
-from app.crud.evaluations.score import EvaluationScore, TraceData, TraceScore
-from app.services.evaluations.validators import DEFAULT_CATEGORY
+from app.crud.evaluations.score import (
+    DEFAULT_CATEGORY,
+    EvaluationScore,
+    TraceData,
+    TraceScore,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/crud/evaluations/merge.py
+++ b/backend/app/crud/evaluations/merge.py
@@ -13,6 +13,7 @@ from collections import Counter
 import numpy as np
 
 from app.crud.evaluations.score import (
+    DEFAULT_CATEGORY,
     EvaluationScore,
     SummaryScore,
     TraceData,
@@ -87,6 +88,9 @@ def _merge_single_trace(existing: TraceData, fresh: TraceData) -> TraceData:
             fresh.get("ground_truth_answer") or existing.get("ground_truth_answer", "")
         ),
         "question_id": fresh.get("question_id") or existing.get("question_id"),
+        "category": (
+            fresh.get("category") or existing.get("category") or DEFAULT_CATEGORY
+        ),
         "scores": list(merged_scores_by_name.values()),
     }
 

--- a/backend/app/crud/evaluations/score.py
+++ b/backend/app/crud/evaluations/score.py
@@ -25,7 +25,22 @@ class TraceData(TypedDict):
     llm_answer: str
     question_id: int | None
     ground_truth_answer: str
+    category: str
     scores: list[TraceScore]
+
+
+class CategoryMetrics(TypedDict):
+    """Aggregated per-category metrics across an eval run.
+
+    `avg_cosine` and `avg_correctness` are the simple arithmetic means of the
+    cosine-similarity and correctness scores for traces in this category; null
+    when the category has no traces with that score.
+    """
+
+    category: str
+    total_evals: int
+    avg_cosine: float | None
+    avg_correctness: float | None
 
 
 class NumericSummaryScore(TypedDict):

--- a/backend/app/crud/evaluations/score.py
+++ b/backend/app/crud/evaluations/score.py
@@ -8,6 +8,9 @@ used throughout the evaluation system.
 from typing import NotRequired, TypedDict
 
 
+DEFAULT_CATEGORY: str = "Other"
+
+
 class TraceScore(TypedDict):
     """A score attached to a trace."""
 

--- a/backend/app/services/evaluations/evaluation.py
+++ b/backend/app/services/evaluations/evaluation.py
@@ -42,7 +42,8 @@ def _compute_category_metrics(
     """
     buckets: dict[str, dict[str, list[float]]] = {}
     for trace in traces:
-        category = trace.get("category") or "Other"
+        raw_category = trace.get("category") or ""
+        category = raw_category.title() if raw_category else "Other"
         cosine_vals: list[float] = []
         correctness_vals: list[float] = []
         # Match by substring so we tolerate provider-specific score naming

--- a/backend/app/services/evaluations/evaluation.py
+++ b/backend/app/services/evaluations/evaluation.py
@@ -346,8 +346,6 @@ def get_evaluation_with_scores(
                 )
 
         if has_cached_traces_db:
-            # Backfill category_metrics on read for runs whose cached score
-            # was written before this feature shipped.
             eval_run.score = _attach_category_metrics(eval_run.score)
             logger.info(
                 f"[get_evaluation_with_scores] Returning traces from DB | "

--- a/backend/app/services/evaluations/evaluation.py
+++ b/backend/app/services/evaluations/evaluation.py
@@ -1,6 +1,7 @@
 """Evaluation run orchestration service."""
 
 import logging
+from typing import Any
 from uuid import UUID
 
 from fastapi import HTTPException
@@ -15,6 +16,7 @@ from app.crud.evaluations import (
     save_score,
     start_evaluation_batch,
 )
+from app.crud.evaluations.score import CategoryMetrics
 from app.models.evaluation import EvaluationRun
 from app.models.llm.request import TextLLMParams, STTLLMParams, TTSLLMParams
 from app.services.llm.providers import LLMProvider
@@ -23,6 +25,74 @@ from app.core.cloud.storage import get_cloud_storage
 from app.core.storage_utils import load_json_from_object_store
 
 logger = logging.getLogger(__name__)
+
+
+def _compute_category_metrics(
+    traces: list[dict[str, Any]],
+) -> list[CategoryMetrics]:
+    """Aggregate cosine + correctness scores per category across the trace list.
+
+    Returns one entry per distinct category with `total_evals` and the mean
+    cosine / correctness scores (or `None` for either if no trace in that
+    category had the score). Categories sorted alphabetically; "Other"
+    always appears last so the default bucket doesn't dominate the UI.
+
+    Backwards-compatible: traces produced before this feature don't carry a
+    `category` field and land in "Other".
+    """
+    buckets: dict[str, dict[str, list[float]]] = {}
+    for trace in traces:
+        category = trace.get("category") or "Other"
+        cosine_vals: list[float] = []
+        correctness_vals: list[float] = []
+        # Match by substring so we tolerate provider-specific score naming
+        # (e.g. "cosine_similarity", "correctness", "correctness_score").
+        for score in trace.get("scores") or []:
+            name = (score.get("name") or "").lower()
+            value = score.get("value")
+            if not isinstance(value, (int, float)):
+                continue
+            if "cosine" in name:
+                cosine_vals.append(float(value))
+            elif "correctness" in name:
+                correctness_vals.append(float(value))
+        slot = buckets.setdefault(category, {"cosine": [], "correctness": [], "count": 0})  # type: ignore[arg-type]
+        slot["cosine"].extend(cosine_vals)
+        slot["correctness"].extend(correctness_vals)
+        slot["count"] = int(slot.get("count", 0)) + 1  # type: ignore[arg-type]
+
+    def _mean(values: list[float]) -> float | None:
+        return round(sum(values) / len(values), 4) if values else None
+
+    metrics: list[CategoryMetrics] = []
+    for category, slot in buckets.items():
+        metrics.append(
+            CategoryMetrics(
+                category=category,
+                total_evals=int(slot["count"]),  # type: ignore[arg-type]
+                avg_cosine=_mean(slot["cosine"]),  # type: ignore[arg-type]
+                avg_correctness=_mean(slot["correctness"]),  # type: ignore[arg-type]
+            )
+        )
+
+    metrics.sort(key=lambda m: (m["category"] == "Other", m["category"]))
+    return metrics
+
+
+def _attach_category_metrics(score: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Idempotently add `category_metrics` to a score dict in place.
+
+    No-op when `score` is None or has no `traces`. Safe to call multiple
+    times — recomputes from the current `traces` so cached scores that
+    predate this feature get backfilled on read.
+    """
+    if not score or not isinstance(score, dict):
+        return score
+    traces = score.get("traces")
+    if not isinstance(traces, list):
+        return score
+    score["category_metrics"] = _compute_category_metrics(traces)
+    return score
 
 
 def start_evaluation(
@@ -253,12 +323,14 @@ def get_evaluation_with_scores(
                     storage=storage, url=eval_run.score_trace_url
                 )
                 if traces is not None:
-                    eval_run.score = {
-                        "summary_scores": (eval_run.score or {}).get(
-                            "summary_scores", []
-                        ),
-                        "traces": traces,
-                    }
+                    eval_run.score = _attach_category_metrics(
+                        {
+                            "summary_scores": (eval_run.score or {}).get(
+                                "summary_scores", []
+                            ),
+                            "traces": traces,
+                        }
+                    )
                     logger.info(
                         f"[get_evaluation_with_scores] Loaded traces from S3 | "
                         f"evaluation_id={evaluation_id} | "
@@ -273,6 +345,9 @@ def get_evaluation_with_scores(
                 )
 
         if has_cached_traces_db:
+            # Backfill category_metrics on read for runs whose cached score
+            # was written before this feature shipped.
+            eval_run.score = _attach_category_metrics(eval_run.score)
             logger.info(
                 f"[get_evaluation_with_scores] Returning traces from DB | "
                 f"evaluation_id={evaluation_id}"
@@ -326,10 +401,12 @@ def get_evaluation_with_scores(
     merged_summary_scores = list(existing_scores_map.values())
 
     # Build final score and persist to S3/DB for future cached reads
-    score = {
-        "summary_scores": merged_summary_scores,
-        "traces": langfuse_score.get("traces", []),
-    }
+    score = _attach_category_metrics(
+        {
+            "summary_scores": merged_summary_scores,
+            "traces": langfuse_score.get("traces", []),
+        }
+    )
 
     eval_run = save_score(
         eval_run_id=eval_run_id,

--- a/backend/app/services/evaluations/validators.py
+++ b/backend/app/services/evaluations/validators.py
@@ -17,7 +17,7 @@ ALLOWED_MIME_TYPES = {
     "application/csv",
     "text/plain",
 }
-DEFAULT_CATEGORY = "Other"
+DEFAULT_CATEGORY: str = "Other"
 
 
 def sanitize_dataset_name(name: str) -> str:

--- a/backend/app/services/evaluations/validators.py
+++ b/backend/app/services/evaluations/validators.py
@@ -17,6 +17,7 @@ ALLOWED_MIME_TYPES = {
     "application/csv",
     "text/plain",
 }
+DEFAULT_CATEGORY = "Other"
 
 
 def sanitize_dataset_name(name: str) -> str:
@@ -114,13 +115,12 @@ async def validate_csv_file(file: UploadFile) -> bytes:
 
 def parse_csv_items(csv_content: bytes) -> list[dict[str, str]]:
     """
-    Parse CSV and extract question/answer pairs.
+    Parse CSV and extract question/answer/category triples.
 
-    Args:
-        csv_content: CSV file content as bytes
-
-    Returns:
-        List of dicts with 'question' and 'answer' keys
+    Required columns: `question`, `answer` (case-insensitive).
+    Optional column: `category` (case-insensitive) — free-text label used for
+    per-category analytics. Missing/blank values default to `"Other"` so old
+    CSVs that predate this column continue to work.
 
     Raises:
         HTTPException: If CSV is invalid or empty
@@ -136,31 +136,41 @@ def parse_csv_items(csv_content: bytes) -> list[dict[str, str]]:
         clean_headers = {
             field.strip().lower(): field for field in csv_reader.fieldnames
         }
+        present = set(clean_headers.keys())
+        required = {"question", "answer"}
+        allowed = required | {"category"}
 
-        # Validate exactly 'question' and 'answer' columns (case-insensitive)
-        if set(clean_headers.keys()) != {"question", "answer"}:
-            extra = set(clean_headers.keys()) - {"question", "answer"}
-            missing = {"question", "answer"} - set(clean_headers.keys())
+        missing = required - present
+        unexpected = present - allowed
+        if missing or unexpected:
             parts = []
             if missing:
                 parts.append(f"Missing: {sorted(missing)}")
-            if extra:
-                parts.append(f"Unexpected: {sorted(extra)}")
+            if unexpected:
+                parts.append(f"Unexpected: {sorted(unexpected)}")
             raise HTTPException(
                 status_code=422,
-                detail=f"CSV must contain exactly 'question' and 'answer' columns. "
-                f"{'. '.join(parts)}. Found columns: {csv_reader.fieldnames}",
+                detail=(
+                    "CSV must contain 'question' and 'answer' columns. "
+                    "'category' is optional. "
+                    f"{'. '.join(parts)}. Found columns: {csv_reader.fieldnames}"
+                ),
             )
 
         question_col = clean_headers["question"]
         answer_col = clean_headers["answer"]
+        category_col = clean_headers.get("category")
 
         items = []
         for row in csv_reader:
             question = row.get(question_col, "").strip()
             answer = row.get(answer_col, "").strip()
-            if question and answer:
-                items.append({"question": question, "answer": answer})
+            if not (question and answer):
+                continue
+            category = (
+                (row.get(category_col, "") or "").strip() if category_col else ""
+            ) or DEFAULT_CATEGORY
+            items.append({"question": question, "answer": answer, "category": category})
 
         if not items:
             raise HTTPException(

--- a/backend/app/services/evaluations/validators.py
+++ b/backend/app/services/evaluations/validators.py
@@ -167,9 +167,10 @@ def parse_csv_items(csv_content: bytes) -> list[dict[str, str]]:
             answer = row.get(answer_col, "").strip()
             if not (question and answer):
                 continue
-            category = (
+            raw_category = (
                 (row.get(category_col, "") or "").strip() if category_col else ""
-            ) or DEFAULT_CATEGORY
+            )
+            category = raw_category.title() if raw_category else DEFAULT_CATEGORY
             items.append({"question": question, "answer": answer, "category": category})
 
         if not items:

--- a/backend/app/services/evaluations/validators.py
+++ b/backend/app/services/evaluations/validators.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 from fastapi import HTTPException, UploadFile
 
+from app.crud.evaluations.score import DEFAULT_CATEGORY  # noqa: F401
+
 logger = logging.getLogger(__name__)
 
 MAX_FILE_SIZE = 1024 * 1024  # 1 MB
@@ -17,7 +19,6 @@ ALLOWED_MIME_TYPES = {
     "application/csv",
     "text/plain",
 }
-DEFAULT_CATEGORY: str = "Other"
 
 
 def sanitize_dataset_name(name: str) -> str:


### PR DESCRIPTION
### Issue: https://github.com/ProjectTech4DevAI/kaapi-backend/issues/844

## Summary
In this PR, added an optional category column to evals so results can be grouped and analyzed by category.
- CSV upload now accepts an optional category column (along with the required question/answer). Blank/missing values default to `Other`.
- Category is passed through Langfuse, saved on dataset items and traces, and read back with scores.
- The eval response now includes per-category metrics (total evals, avg cosine, avg correctness).
- Older datasets, CSVs, and cached results still work, anything without a category falls back to "Other".

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.