### PR TITLE
Evalution: Step-forward merge

### DIFF
--- a/backend/app/crud/evaluations/__init__.py
+++ b/backend/app/crud/evaluations/__init__.py
@@ -31,6 +31,11 @@ from app.crud.evaluations.langfuse import (
     update_traces_with_cosine_scores,
     upload_dataset_to_langfuse,
 )
+from app.crud.evaluations.merge import (
+    compute_summary_scores,
+    merge_scores_step_forward,
+    merge_trace_data,
+)
 from app.crud.evaluations.processing import (
     check_and_process_evaluation,
     poll_all_pending_evaluations,
@@ -79,6 +84,10 @@ __all__ = [
     "fetch_trace_scores_from_langfuse",
     "update_traces_with_cosine_scores",
     "upload_dataset_to_langfuse",
+    # Merge (step-forward resync)
+    "compute_summary_scores",
+    "merge_scores_step_forward",
+    "merge_trace_data",
     # Score types
     "CategoricalSummaryScore",
     "EvaluationScore",

--- a/backend/app/crud/evaluations/__init__.py
+++ b/backend/app/crud/evaluations/__init__.py
@@ -31,11 +31,7 @@ from app.crud.evaluations.langfuse import (
     update_traces_with_cosine_scores,
     upload_dataset_to_langfuse,
 )
-from app.crud.evaluations.merge import (
-    compute_summary_scores,
-    merge_scores_step_forward,
-    merge_trace_data,
-)
+from app.crud.evaluations.merge import merge_scores_step_forward
 from app.crud.evaluations.processing import (
     check_and_process_evaluation,
     poll_all_pending_evaluations,
@@ -85,9 +81,7 @@ __all__ = [
     "update_traces_with_cosine_scores",
     "upload_dataset_to_langfuse",
     # Merge (step-forward resync)
-    "compute_summary_scores",
     "merge_scores_step_forward",
-    "merge_trace_data",
     # Score types
     "CategoricalSummaryScore",
     "EvaluationScore",

--- a/backend/app/crud/evaluations/core.py
+++ b/backend/app/crud/evaluations/core.py
@@ -315,6 +315,7 @@ def get_or_fetch_score(
         langfuse=langfuse,
         dataset_name=eval_run.dataset_name,
         run_name=eval_run.run_name,
+        project_id=eval_run.project_id,
     )
 
     # Merge summary_scores: existing scores + new scores from Langfuse

--- a/backend/app/crud/evaluations/langfuse.py
+++ b/backend/app/crud/evaluations/langfuse.py
@@ -328,6 +328,7 @@ def fetch_trace_scores_from_langfuse(
     langfuse: Langfuse,
     dataset_name: str,
     run_name: str,
+    project_id: int | None = None,
 ) -> EvaluationScore:
     """
     Fetch trace scores from Langfuse for an evaluation run.
@@ -529,18 +530,14 @@ def fetch_trace_scores_from_langfuse(
                 f"fetches failed. Try again later."
             )
 
-        # Partial failure below the outage threshold: do NOT fail silently. Make it
-        # explicit that this fetch is incomplete. The caller merges this result with
-        # the cached traces (step-forward), so the missing traces are preserved and a
-        # later resync can fill them in.
+        # Partial failure below the outage threshold: log it instead of dropping
+        # traces silently. The caller backfills the missing ones on a later resync.
         if total_failures > 0:
             logger.warning(
                 f"[fetch_trace_scores_from_langfuse] Partial fetch | "
                 f"fetched={len(traces)}/{len(trace_ids)} | "
-                f"failed={total_failures} | "
                 f"failed_trace_ids={failed_trace_ids} | "
-                f"dataset={dataset_name} | run={run_name} | "
-                f"missing traces will be backfilled on a later resync"
+                f"dataset={dataset_name} | run={run_name} | project_id={project_id}"
             )
 
         # 4. Calculate summary scores from the fetched traces.

--- a/backend/app/crud/evaluations/langfuse.py
+++ b/backend/app/crud/evaluations/langfuse.py
@@ -12,9 +12,9 @@ import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
-import numpy as np
 from langfuse import Langfuse
 
+from app.crud.evaluations.merge import compute_summary_scores
 from app.crud.evaluations.score import EvaluationScore, TraceData, TraceScore
 
 logger = logging.getLogger(__name__)
@@ -412,13 +412,14 @@ def fetch_trace_scores_from_langfuse(
 
         # 3. Fetch trace details with scores concurrently
         traces: list[TraceData] = []
-        # Track score aggregations by name: {name: {"data_type": str, "values": list}}
-        score_aggregations: dict[str, dict[str, Any]] = {}
 
         # Circuit breaker: abort early if too many consecutive failures
         max_consecutive_failures = 5
         consecutive_failures = 0
         total_failures = 0
+        # Track which traces could not be fetched so the failure is explicit in
+        # logs (instead of silently dropping them from the result).
+        failed_trace_ids: list[str] = []
 
         def _fetch_single_trace(trace_id: str) -> TraceData | None:
             """Fetch a single trace from Langfuse and extract its data."""
@@ -495,25 +496,12 @@ def fetch_trace_scores_from_langfuse(
                         continue
 
                     consecutive_failures = 0
-
-                    # Aggregate scores for summary calculation
-                    for score_entry in trace_data["scores"]:
-                        score_name = score_entry["name"]
-                        score_value = score_entry["value"]
-                        data_type = score_entry["data_type"]
-                        if score_value is not None:
-                            if score_name not in score_aggregations:
-                                score_aggregations[score_name] = {
-                                    "data_type": data_type,
-                                    "values": [],
-                                }
-                            score_aggregations[score_name]["values"].append(score_value)
-
                     traces.append(trace_data)
 
                 except Exception as e:
                     consecutive_failures += 1
                     total_failures += 1
+                    failed_trace_ids.append(trace_id)
                     logger.warning(
                         f"[fetch_trace_scores_from_langfuse] Failed to fetch trace | "
                         f"trace_id={trace_id} | error={e}"
@@ -541,39 +529,22 @@ def fetch_trace_scores_from_langfuse(
                 f"fetches failed. Try again later."
             )
 
-        # 4. Calculate summary scores for all scores that have at least one value
-        summary_scores = []
-        for score_name, agg_data in score_aggregations.items():
-            data_type = agg_data["data_type"]
-            values = agg_data["values"]
+        # Partial failure below the outage threshold: do NOT fail silently. Make it
+        # explicit that this fetch is incomplete. The caller merges this result with
+        # the cached traces (step-forward), so the missing traces are preserved and a
+        # later resync can fill them in.
+        if total_failures > 0:
+            logger.warning(
+                f"[fetch_trace_scores_from_langfuse] Partial fetch | "
+                f"fetched={len(traces)}/{len(trace_ids)} | "
+                f"failed={total_failures} | "
+                f"failed_trace_ids={failed_trace_ids} | "
+                f"dataset={dataset_name} | run={run_name} | "
+                f"missing traces will be backfilled on a later resync"
+            )
 
-            if data_type == "CATEGORICAL":
-                # For categorical scores, compute distribution
-                distribution: dict[str, int] = {}
-                for val in values:
-                    str_val = str(val)
-                    distribution[str_val] = distribution.get(str_val, 0) + 1
-
-                summary_scores.append(
-                    {
-                        "name": score_name,
-                        "distribution": distribution,
-                        "total_pairs": len(values),
-                        "data_type": data_type,
-                    }
-                )
-            else:
-                # For numeric scores, compute avg and std (rounded to 2 decimal places)
-                numeric_values = [float(v) for v in values]
-                summary_scores.append(
-                    {
-                        "name": score_name,
-                        "avg": round(float(np.mean(numeric_values)), 2),
-                        "std": round(float(np.std(numeric_values)), 2),
-                        "total_pairs": len(numeric_values),
-                        "data_type": data_type,
-                    }
-                )
+        # 4. Calculate summary scores from the fetched traces.
+        summary_scores = compute_summary_scores(traces)
 
         result: EvaluationScore = {
             "summary_scores": summary_scores,
@@ -582,7 +553,8 @@ def fetch_trace_scores_from_langfuse(
 
         logger.info(
             f"[fetch_trace_scores_from_langfuse] Successfully fetched scores | "
-            f"total_traces={len(traces)} | score_names={list(score_aggregations.keys())}"
+            f"total_traces={len(traces)} | "
+            f"score_names={[s['name'] for s in summary_scores]}"
         )
 
         return result

--- a/backend/app/crud/evaluations/merge.py
+++ b/backend/app/crud/evaluations/merge.py
@@ -1,0 +1,215 @@
+"""
+Step-forward merge helpers for evaluation trace scores.
+
+A Langfuse resync may return fewer traces than a previous sync (transient
+per-trace fetch failures, eventual consistency on scores still being written,
+etc.). Blindly overwriting the cached result with the freshly fetched one can
+therefore lose data and make the visible pair count go *down* (e.g. 29/30 -> 27/30).
+
+These helpers make resync monotonic ("always a step forward"): the cached
+traces are merged with the freshly fetched ones by ``trace_id`` so that a trace
+we already have is never dropped, and summary statistics are recomputed from the
+merged union so the totals stay consistent with the traces.
+"""
+
+import logging
+from typing import Any
+
+import numpy as np
+
+from app.crud.evaluations.score import (
+    EvaluationScore,
+    SummaryScore,
+    TraceData,
+    TraceScore,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def compute_summary_scores(traces: list[TraceData]) -> list[SummaryScore]:
+    """
+    Recompute summary statistics from a list of traces.
+
+    Aggregates every per-trace score by name. Numeric scores get avg/std,
+    categorical scores get a value distribution. ``total_pairs`` is the number of
+    traces that carry a non-null value for that score.
+
+    Args:
+        traces: Traces to aggregate (typically the merged union of cached + fresh).
+
+    Returns:
+        Summary scores derived from ``traces``.
+    """
+    # Track aggregations by score name: {name: {"data_type": str, "values": list}}
+    score_aggregations: dict[str, dict[str, Any]] = {}
+
+    for trace in traces:
+        for score_entry in trace.get("scores", []):
+            score_name = score_entry["name"]
+            score_value = score_entry["value"]
+            data_type = score_entry.get("data_type") or "NUMERIC"
+            if score_value is None:
+                continue
+            if score_name not in score_aggregations:
+                score_aggregations[score_name] = {
+                    "data_type": data_type,
+                    "values": [],
+                }
+            score_aggregations[score_name]["values"].append(score_value)
+
+    summary_scores: list[SummaryScore] = []
+    for score_name, agg_data in score_aggregations.items():
+        data_type = agg_data["data_type"]
+        values = agg_data["values"]
+
+        if data_type == "CATEGORICAL":
+            distribution: dict[str, int] = {}
+            for val in values:
+                str_val = str(val)
+                distribution[str_val] = distribution.get(str_val, 0) + 1
+            summary_scores.append(
+                {
+                    "name": score_name,
+                    "distribution": distribution,
+                    "total_pairs": len(values),
+                    "data_type": data_type,
+                }
+            )
+        else:
+            numeric_values = [float(v) for v in values]
+            summary_scores.append(
+                {
+                    "name": score_name,
+                    "avg": round(float(np.mean(numeric_values)), 2),
+                    "std": round(float(np.std(numeric_values)), 2),
+                    "total_pairs": len(numeric_values),
+                    "data_type": data_type,
+                }
+            )
+
+    return summary_scores
+
+
+def _merge_single_trace(existing: TraceData, fresh: TraceData) -> TraceData:
+    """
+    Merge two versions of the same trace (same ``trace_id``).
+
+    Scores are unioned by name; the freshly fetched value wins on conflict (it is
+    the more up-to-date one) and any score present only in one version is kept.
+    Text fields prefer the fresh value when it is non-empty, otherwise the cached
+    one — so we never regress a populated field back to empty.
+    """
+    merged_scores_by_name: dict[str, TraceScore] = {
+        s["name"]: s for s in existing.get("scores", [])
+    }
+    for s in fresh.get("scores", []):
+        merged_scores_by_name[s["name"]] = s
+
+    return {
+        "trace_id": fresh.get("trace_id") or existing.get("trace_id", ""),
+        "question": fresh.get("question") or existing.get("question", ""),
+        "llm_answer": fresh.get("llm_answer") or existing.get("llm_answer", ""),
+        "ground_truth_answer": (
+            fresh.get("ground_truth_answer") or existing.get("ground_truth_answer", "")
+        ),
+        "question_id": fresh.get("question_id") or existing.get("question_id"),
+        "scores": list(merged_scores_by_name.values()),
+    }
+
+
+def merge_trace_data(
+    existing_traces: list[TraceData],
+    fresh_traces: list[TraceData],
+) -> tuple[list[TraceData], dict[str, int]]:
+    """
+    Step-forward merge of cached traces with freshly fetched ones.
+
+    Union by ``trace_id``:
+    - present only in the cache (Langfuse failed to return it this time) -> kept
+    - present only in the fresh fetch (newly available) -> added
+    - present in both -> merged via :func:`_merge_single_trace`
+
+    This guarantees the merged result is never smaller than the cache, so repeated
+    resyncs can only grow the pair count (e.g. 15/30 -> 24/30 -> 30/30).
+
+    Args:
+        existing_traces: Previously cached traces (may be empty on first sync).
+        fresh_traces: Traces fetched from Langfuse in this resync.
+
+    Returns:
+        Tuple of (merged traces, stats) where stats counts ``reused`` (cache kept
+        as-is), ``updated`` (cache enriched with fresh data), and ``added`` (new).
+    """
+    existing_by_id: dict[str, TraceData] = {t["trace_id"]: t for t in existing_traces}
+    fresh_by_id: dict[str, TraceData] = {t["trace_id"]: t for t in fresh_traces}
+
+    # Preserve cache order first, then append genuinely new traces.
+    ordered_ids = list(existing_by_id.keys()) + [
+        tid for tid in fresh_by_id if tid not in existing_by_id
+    ]
+
+    merged: list[TraceData] = []
+    stats = {"reused": 0, "updated": 0, "added": 0}
+
+    for trace_id in ordered_ids:
+        existing = existing_by_id.get(trace_id)
+        fresh = fresh_by_id.get(trace_id)
+
+        if existing and not fresh:
+            merged.append(existing)
+            stats["reused"] += 1
+        elif fresh and not existing:
+            merged.append(fresh)
+            stats["added"] += 1
+        else:
+            merged_trace = _merge_single_trace(existing, fresh)
+            merged.append(merged_trace)
+            if merged_trace == existing:
+                stats["reused"] += 1
+            else:
+                stats["updated"] += 1
+
+    return merged, stats
+
+
+def merge_scores_step_forward(
+    existing_score: EvaluationScore | None,
+    fresh_score: EvaluationScore,
+) -> tuple[EvaluationScore, dict[str, int]]:
+    """
+    Merge a freshly fetched evaluation score into the cached one, monotonically.
+
+    Traces are merged step-forward (see :func:`merge_trace_data`) and summary
+    statistics are recomputed from the merged traces so the totals match. Any
+    summary score that has no per-trace representation (e.g. a summary-only metric)
+    is preserved from the existing score.
+
+    Args:
+        existing_score: Previously cached score (``None``/empty on first sync).
+        fresh_score: Score freshly fetched from Langfuse.
+
+    Returns:
+        Tuple of (merged EvaluationScore, merge stats).
+    """
+    existing_traces = (existing_score or {}).get("traces", []) or []
+    fresh_traces = fresh_score.get("traces", []) or []
+
+    merged_traces, stats = merge_trace_data(existing_traces, fresh_traces)
+
+    # Recompute summaries from the union so total_pairs reflects the merged set.
+    recomputed_summary = compute_summary_scores(merged_traces)
+
+    # Preserve any summary-only score (no per-trace value) from the existing score;
+    # recomputed summaries (derived from the merged traces) take precedence by name.
+    summary_by_name: dict[str, SummaryScore] = {
+        s["name"]: s for s in (existing_score or {}).get("summary_scores", [])
+    }
+    for s in recomputed_summary:
+        summary_by_name[s["name"]] = s
+
+    merged: EvaluationScore = {
+        "summary_scores": list(summary_by_name.values()),
+        "traces": merged_traces,
+    }
+    return merged, stats

--- a/backend/app/crud/evaluations/merge.py
+++ b/backend/app/crud/evaluations/merge.py
@@ -1,19 +1,14 @@
 """
 Step-forward merge helpers for evaluation trace scores.
 
-A Langfuse resync may return fewer traces than a previous sync (transient
-per-trace fetch failures, eventual consistency on scores still being written,
-etc.). Blindly overwriting the cached result with the freshly fetched one can
-therefore lose data and make the visible pair count go *down* (e.g. 29/30 -> 27/30).
-
-These helpers make resync monotonic ("always a step forward"): the cached
-traces are merged with the freshly fetched ones by ``trace_id`` so that a trace
-we already have is never dropped, and summary statistics are recomputed from the
-merged union so the totals stay consistent with the traces.
+A Langfuse resync can return fewer traces than before (transient fetch failures,
+scores not yet written). Merging by ``trace_id`` instead of overwriting keeps the
+result monotonic, so the pair count can only grow across resyncs (never 29 -> 27).
 """
 
+import itertools
 import logging
-from typing import Any
+from collections import Counter
 
 import numpy as np
 
@@ -29,34 +24,20 @@ logger = logging.getLogger(__name__)
 
 def compute_summary_scores(traces: list[TraceData]) -> list[SummaryScore]:
     """
-    Recompute summary statistics from a list of traces.
-
-    Aggregates every per-trace score by name. Numeric scores get avg/std,
-    categorical scores get a value distribution. ``total_pairs`` is the number of
-    traces that carry a non-null value for that score.
-
-    Args:
-        traces: Traces to aggregate (typically the merged union of cached + fresh).
-
-    Returns:
-        Summary scores derived from ``traces``.
+    Aggregate per-trace scores by name: numeric scores get avg/std, categorical
+    scores get a value distribution. ``total_pairs`` counts non-null values.
     """
-    # Track aggregations by score name: {name: {"data_type": str, "values": list}}
-    score_aggregations: dict[str, dict[str, Any]] = {}
-
-    for trace in traces:
-        for score_entry in trace.get("scores", []):
-            score_name = score_entry["name"]
-            score_value = score_entry["value"]
-            data_type = score_entry.get("data_type") or "NUMERIC"
-            if score_value is None:
-                continue
-            if score_name not in score_aggregations:
-                score_aggregations[score_name] = {
-                    "data_type": data_type,
-                    "values": [],
-                }
-            score_aggregations[score_name]["values"].append(score_value)
+    # {name: {"data_type": str, "values": list}}
+    score_aggregations: dict[str, dict] = {}
+    all_scores = itertools.chain.from_iterable(t.get("scores", []) for t in traces)
+    for entry in all_scores:
+        if entry["value"] is None:
+            continue
+        agg = score_aggregations.setdefault(
+            entry["name"],
+            {"data_type": entry.get("data_type") or "NUMERIC", "values": []},
+        )
+        agg["values"].append(entry["value"])
 
     summary_scores: list[SummaryScore] = []
     for score_name, agg_data in score_aggregations.items():
@@ -64,14 +45,10 @@ def compute_summary_scores(traces: list[TraceData]) -> list[SummaryScore]:
         values = agg_data["values"]
 
         if data_type == "CATEGORICAL":
-            distribution: dict[str, int] = {}
-            for val in values:
-                str_val = str(val)
-                distribution[str_val] = distribution.get(str_val, 0) + 1
             summary_scores.append(
                 {
                     "name": score_name,
-                    "distribution": distribution,
+                    "distribution": dict(Counter(str(v) for v in values)),
                     "total_pairs": len(values),
                     "data_type": data_type,
                 }
@@ -93,18 +70,14 @@ def compute_summary_scores(traces: list[TraceData]) -> list[SummaryScore]:
 
 def _merge_single_trace(existing: TraceData, fresh: TraceData) -> TraceData:
     """
-    Merge two versions of the same trace (same ``trace_id``).
-
-    Scores are unioned by name; the freshly fetched value wins on conflict (it is
-    the more up-to-date one) and any score present only in one version is kept.
-    Text fields prefer the fresh value when it is non-empty, otherwise the cached
-    one — so we never regress a populated field back to empty.
+    Merge two versions of the same trace. Scores are unioned by name (fresh wins
+    on conflict); text fields prefer the fresh value when non-empty, else cached.
     """
     merged_scores_by_name: dict[str, TraceScore] = {
-        s["name"]: s for s in existing.get("scores", [])
+        score["name"]: score for score in existing.get("scores", [])
     }
-    for s in fresh.get("scores", []):
-        merged_scores_by_name[s["name"]] = s
+    for fresh_score in fresh.get("scores", []):
+        merged_scores_by_name[fresh_score["name"]] = fresh_score
 
     return {
         "trace_id": fresh.get("trace_id") or existing.get("trace_id", ""),
@@ -118,28 +91,30 @@ def _merge_single_trace(existing: TraceData, fresh: TraceData) -> TraceData:
     }
 
 
+def _reconcile_trace(
+    existing: TraceData | None,
+    fresh: TraceData | None,
+) -> tuple[TraceData, str]:
+    """
+    Pick the winning version of one trace and classify it as ``added``, ``reused``,
+    or ``updated``. Exactly one of ``existing``/``fresh`` may be None, never both.
+    """
+    if existing is None:
+        return fresh, "added"
+    if fresh is None:
+        return existing, "reused"
+    merged = _merge_single_trace(existing, fresh)
+    return merged, "reused" if merged == existing else "updated"
+
+
 def merge_trace_data(
     existing_traces: list[TraceData],
     fresh_traces: list[TraceData],
 ) -> tuple[list[TraceData], dict[str, int]]:
     """
-    Step-forward merge of cached traces with freshly fetched ones.
-
-    Union by ``trace_id``:
-    - present only in the cache (Langfuse failed to return it this time) -> kept
-    - present only in the fresh fetch (newly available) -> added
-    - present in both -> merged via :func:`_merge_single_trace`
-
-    This guarantees the merged result is never smaller than the cache, so repeated
-    resyncs can only grow the pair count (e.g. 15/30 -> 24/30 -> 30/30).
-
-    Args:
-        existing_traces: Previously cached traces (may be empty on first sync).
-        fresh_traces: Traces fetched from Langfuse in this resync.
-
-    Returns:
-        Tuple of (merged traces, stats) where stats counts ``reused`` (cache kept
-        as-is), ``updated`` (cache enriched with fresh data), and ``added`` (new).
+    Union cached and fresh traces by ``trace_id`` (a trace only in the cache is
+    kept, never dropped), so the result is never smaller than the cache. Returns
+    the merged traces and a ``{reused, updated, added}`` count.
     """
     existing_by_id: dict[str, TraceData] = {t["trace_id"]: t for t in existing_traces}
     fresh_by_id: dict[str, TraceData] = {t["trace_id"]: t for t in fresh_traces}
@@ -153,22 +128,11 @@ def merge_trace_data(
     stats = {"reused": 0, "updated": 0, "added": 0}
 
     for trace_id in ordered_ids:
-        existing = existing_by_id.get(trace_id)
-        fresh = fresh_by_id.get(trace_id)
-
-        if existing and not fresh:
-            merged.append(existing)
-            stats["reused"] += 1
-        elif fresh and not existing:
-            merged.append(fresh)
-            stats["added"] += 1
-        else:
-            merged_trace = _merge_single_trace(existing, fresh)
-            merged.append(merged_trace)
-            if merged_trace == existing:
-                stats["reused"] += 1
-            else:
-                stats["updated"] += 1
+        trace, category = _reconcile_trace(
+            existing_by_id.get(trace_id), fresh_by_id.get(trace_id)
+        )
+        merged.append(trace)
+        stats[category] += 1
 
     return merged, stats
 
@@ -178,30 +142,17 @@ def merge_scores_step_forward(
     fresh_score: EvaluationScore,
 ) -> tuple[EvaluationScore, dict[str, int]]:
     """
-    Merge a freshly fetched evaluation score into the cached one, monotonically.
-
-    Traces are merged step-forward (see :func:`merge_trace_data`) and summary
-    statistics are recomputed from the merged traces so the totals match. Any
-    summary score that has no per-trace representation (e.g. a summary-only metric)
-    is preserved from the existing score.
-
-    Args:
-        existing_score: Previously cached score (``None``/empty on first sync).
-        fresh_score: Score freshly fetched from Langfuse.
-
-    Returns:
-        Tuple of (merged EvaluationScore, merge stats).
+    Merge a freshly fetched score into the cached one monotonically: traces are
+    merged step-forward and summaries recomputed from the union. Summary-only
+    scores (no per-trace value) are preserved from the existing score.
     """
     existing_traces = (existing_score or {}).get("traces", []) or []
     fresh_traces = fresh_score.get("traces", []) or []
 
     merged_traces, stats = merge_trace_data(existing_traces, fresh_traces)
-
-    # Recompute summaries from the union so total_pairs reflects the merged set.
     recomputed_summary = compute_summary_scores(merged_traces)
 
-    # Preserve any summary-only score (no per-trace value) from the existing score;
-    # recomputed summaries (derived from the merged traces) take precedence by name.
+    # Recomputed summaries take precedence; summary-only scores survive.
     summary_by_name: dict[str, SummaryScore] = {
         s["name"]: s for s in (existing_score or {}).get("summary_scores", [])
     }

--- a/backend/app/services/evaluations/evaluation.py
+++ b/backend/app/services/evaluations/evaluation.py
@@ -7,14 +7,17 @@ from fastapi import HTTPException
 from sqlmodel import Session
 
 from app.crud.evaluations import (
+    EvaluationScore,
     create_evaluation_run,
     fetch_trace_scores_from_langfuse,
     get_dataset_by_id,
     get_evaluation_run_by_id,
+    merge_scores_step_forward,
     resolve_evaluation_config,
     save_score,
     start_evaluation_batch,
 )
+from app.crud.evaluations.score import TraceData
 from app.models.evaluation import EvaluationRun
 from app.models.llm.request import TextLLMParams, STTLLMParams, TTSLLMParams
 from app.services.llm.providers import LLMProvider
@@ -176,6 +179,51 @@ def start_evaluation(
         return eval_run
 
 
+def _load_cached_traces(
+    session: Session,
+    project_id: int,
+    eval_run: EvaluationRun,
+) -> tuple[list[TraceData], bool]:
+    """
+    Load previously cached traces for an evaluation run.
+
+    Traces are cached in S3 (pointed to by ``score_trace_url``) with a DB fallback
+    (``score["traces"]``). This returns whatever is cached so a resync can merge
+    against it instead of overwriting it.
+
+    Returns:
+        Tuple of (traces, load_failed). ``load_failed`` is True only when a cache
+        pointer exists but could not be read — the caller must then avoid
+        overwriting the cache, otherwise it would lose data. A genuinely empty
+        cache (first sync) returns ([], False).
+    """
+    if eval_run.score_trace_url:
+        try:
+            storage = get_cloud_storage(session=session, project_id=project_id)
+            traces = load_json_from_object_store(
+                storage=storage, url=eval_run.score_trace_url
+            )
+            if traces is not None:
+                return traces, False
+            logger.warning(
+                f"[_load_cached_traces] Cached traces URL returned no data | "
+                f"evaluation_id={eval_run.id} | url={eval_run.score_trace_url}"
+            )
+            return [], True
+        except Exception as e:
+            logger.warning(
+                f"[_load_cached_traces] Error loading traces from S3: {e} | "
+                f"evaluation_id={eval_run.id}",
+                exc_info=True,
+            )
+            return [], True
+
+    if eval_run.score is not None and "traces" in eval_run.score:
+        return eval_run.score.get("traces", []) or [], False
+
+    return [], False
+
+
 def get_evaluation_with_scores(
     session: Session,
     evaluation_id: int,
@@ -230,69 +278,57 @@ def get_evaluation_with_scores(
             )
         return eval_run, None
 
-    # Check if we already have cached summary_scores
-    has_summary_scores = (
-        eval_run.score is not None and "summary_scores" in eval_run.score
-    )
-
     # If not requesting trace info, return existing score (with summary_scores)
     if not get_trace_info:
         return eval_run, None
 
-    # Caching strategy: On the first request, trace scores are fetched from Langfuse
-    # and a copy is stored in S3. Subsequent requests serve from
-    # S3 instead of Langfuse, which is significantly faster. Use resync_score=true
-    # to bypass the cache and re-fetch from Langfuse and store to S3 again.
-    has_cached_traces_s3 = eval_run.score_trace_url is not None
-    has_cached_traces_db = eval_run.score is not None and "traces" in eval_run.score
-    if not resync_score:
-        if has_cached_traces_s3:
-            try:
-                storage = get_cloud_storage(session=session, project_id=project_id)
-                traces = load_json_from_object_store(
-                    storage=storage, url=eval_run.score_trace_url
-                )
-                if traces is not None:
-                    eval_run.score = {
-                        "summary_scores": (eval_run.score or {}).get(
-                            "summary_scores", []
-                        ),
-                        "traces": traces,
-                    }
-                    logger.info(
-                        f"[get_evaluation_with_scores] Loaded traces from S3 | "
-                        f"evaluation_id={evaluation_id} | "
-                        f"traces_count={len(traces)}"
-                    )
-                    return eval_run, None
-            except Exception as e:
-                logger.warning(
-                    f"[get_evaluation_with_scores] Error loading traces from S3: {e} | "
-                    f"evaluation_id={evaluation_id}",
-                    exc_info=True,
-                )
+    # Caching strategy: trace scores are fetched from Langfuse once, then cached
+    # (traces in S3, summary in the DB). Normal reads serve from that cache, which is
+    # much faster than hitting Langfuse. resync_score=true bypasses the cache.
+    #
+    # A resync re-fetches from Langfuse and MERGES the result with the cached traces
+    # step-forward (union by trace_id), so the cached pair count can only grow. This
+    # prevents a transient Langfuse fetch failure from making the count go *down*
+    # (e.g. 29/30 -> 27/30): a partial sync at worst contributes nothing new, and a
+    # later resync can backfill the missing traces (15/30 -> 24/30 -> 30/30).
+    cached_traces, cache_load_failed = _load_cached_traces(
+        session=session, project_id=project_id, eval_run=eval_run
+    )
 
-        if has_cached_traces_db:
-            logger.info(
-                f"[get_evaluation_with_scores] Returning traces from DB | "
-                f"evaluation_id={evaluation_id}"
-            )
-            return eval_run, None
+    if not resync_score and cached_traces:
+        eval_run.score = {
+            "summary_scores": (eval_run.score or {}).get("summary_scores", []),
+            "traces": cached_traces,
+        }
+        logger.info(
+            f"[get_evaluation_with_scores] Served traces from cache | "
+            f"evaluation_id={evaluation_id} | traces_count={len(cached_traces)}"
+        )
+        return eval_run, None
 
-    # Resync requested — fetch fresh scores from Langfuse
+    # On resync, if a cache pointer exists but we could not read it, do NOT overwrite
+    # it with a fresh-only fetch (that could regress the cached pair count). Surface
+    # the error and leave the existing cache untouched.
+    if resync_score and cache_load_failed:
+        logger.warning(
+            f"[get_evaluation_with_scores] Skipping resync to avoid data loss | "
+            f"evaluation_id={evaluation_id} | reason=could_not_read_cached_traces"
+        )
+        return eval_run, (
+            "Could not read existing cached traces; skipping resync to avoid "
+            "losing data. Please try again."
+        )
+
+    # Fetch fresh scores from Langfuse (first sync, or resync).
     langfuse = get_langfuse_client(
         session=session,
         org_id=organization_id,
         project_id=project_id,
     )
 
-    # Capture data needed for Langfuse fetch and DB update
     dataset_name = eval_run.dataset_name
     run_name = eval_run.run_name
     eval_run_id = eval_run.id
-    existing_summary_scores = (
-        eval_run.score.get("summary_scores", []) if has_summary_scores else []
-    )
 
     try:
         langfuse_score = fetch_trace_scores_from_langfuse(
@@ -314,31 +350,33 @@ def get_evaluation_with_scores(
         )
         return eval_run, f"Failed to fetch trace info from Langfuse: {str(e)}"
 
-    # Merge summary_scores: existing scores + new scores from Langfuse
-    # Create a map of existing scores by name
-    existing_scores_map = {s["name"]: s for s in existing_summary_scores}
-    langfuse_summary_scores = langfuse_score.get("summary_scores", [])
-
-    # Merge: Langfuse scores take precedence (more up-to-date)
-    for langfuse_summary in langfuse_summary_scores:
-        existing_scores_map[langfuse_summary["name"]] = langfuse_summary
-
-    merged_summary_scores = list(existing_scores_map.values())
-
-    # Build final score and persist to S3/DB for future cached reads
-    score = {
-        "summary_scores": merged_summary_scores,
-        "traces": langfuse_score.get("traces", []),
+    # Step-forward merge: combine the freshly fetched score with the cached one so the
+    # result never shrinks, then recompute summaries from the merged union.
+    existing_score: EvaluationScore = {
+        "summary_scores": (eval_run.score or {}).get("summary_scores", []),
+        "traces": cached_traces,
     }
+    merged_score, merge_stats = merge_scores_step_forward(
+        existing_score=existing_score,
+        fresh_score=langfuse_score,
+    )
+
+    logger.info(
+        f"[get_evaluation_with_scores] Merged traces step-forward | "
+        f"evaluation_id={evaluation_id} | cached={len(cached_traces)} | "
+        f"fetched={len(langfuse_score.get('traces', []))} | "
+        f"merged={len(merged_score['traces'])} | reused={merge_stats['reused']} | "
+        f"updated={merge_stats['updated']} | added={merge_stats['added']}"
+    )
 
     eval_run = save_score(
         eval_run_id=eval_run_id,
         organization_id=organization_id,
         project_id=project_id,
-        score=score,
+        score=merged_score,
     )
 
     if eval_run:
-        eval_run.score = score
+        eval_run.score = merged_score
 
     return eval_run, None

--- a/backend/app/services/evaluations/evaluation.py
+++ b/backend/app/services/evaluations/evaluation.py
@@ -335,6 +335,7 @@ def get_evaluation_with_scores(
             langfuse=langfuse,
             dataset_name=dataset_name,
             run_name=run_name,
+            project_id=project_id,
         )
     except ValueError as e:
         logger.warning(

--- a/backend/app/tests/crud/evaluations/test_merge.py
+++ b/backend/app/tests/crud/evaluations/test_merge.py
@@ -1,0 +1,143 @@
+"""Tests for step-forward trace merge helpers used on Langfuse resync."""
+
+from app.crud.evaluations.merge import (
+    compute_summary_scores,
+    merge_scores_step_forward,
+    merge_trace_data,
+)
+
+
+def _trace(trace_id, value=1.0, name="accuracy", data_type="NUMERIC"):
+    return {
+        "trace_id": trace_id,
+        "question": f"q{trace_id}",
+        "llm_answer": "a",
+        "ground_truth_answer": "g",
+        "question_id": int(trace_id),
+        "scores": [{"name": name, "value": value, "data_type": data_type}],
+    }
+
+
+class TestMergeTraceData:
+    def test_empty_cache_returns_fresh(self):
+        fresh = [_trace("0"), _trace("1")]
+        merged, stats = merge_trace_data([], fresh)
+        assert len(merged) == 2
+        assert stats == {"reused": 0, "updated": 0, "added": 2}
+
+    def test_grows_monotonically(self):
+        """15 -> 24 -> 30 across successive syncs."""
+        sync1 = [_trace(str(i)) for i in range(15)]
+        sync2 = [_trace(str(i)) for i in range(5, 24)]
+        sync3 = [_trace(str(i)) for i in range(30)]
+
+        m1, _ = merge_trace_data([], sync1)
+        m2, s2 = merge_trace_data(m1, sync2)
+        m3, s3 = merge_trace_data(m2, sync3)
+
+        assert len(m1) == 15
+        assert len(m2) == 24
+        assert s2 == {"reused": 15, "updated": 0, "added": 9}
+        assert len(m3) == 30
+        assert s3 == {"reused": 24, "updated": 0, "added": 6}
+
+    def test_fewer_fresh_traces_keeps_cached(self):
+        """A partial fetch (27) must not drop cached traces (29)."""
+        cached = [_trace(str(i)) for i in range(29)]
+        fresh = [_trace(str(i)) for i in range(27)]
+        merged, stats = merge_trace_data(cached, fresh)
+        assert len(merged) == 29
+        assert stats["reused"] == 29
+        assert stats["added"] == 0
+
+    def test_additional_score_unions(self):
+        """A trace gaining a new score is enriched, not replaced wholesale."""
+        existing = [_trace("1", name="accuracy")]
+        fresh = [
+            {
+                "trace_id": "1",
+                "question": "q1",
+                "llm_answer": "a",
+                "ground_truth_answer": "g",
+                "question_id": 1,
+                "scores": [{"name": "relevance", "value": 0.9, "data_type": "NUMERIC"}],
+            }
+        ]
+        merged, stats = merge_trace_data(existing, fresh)
+        names = sorted(s["name"] for s in merged[0]["scores"])
+        assert names == ["accuracy", "relevance"]
+        assert stats["updated"] == 1
+
+    def test_fresh_value_wins_on_conflict(self):
+        existing = [_trace("1", value=0.5)]
+        fresh = [_trace("1", value=0.8)]
+        merged, _ = merge_trace_data(existing, fresh)
+        assert merged[0]["scores"][0]["value"] == 0.8
+
+    def test_identical_trace_is_reused(self):
+        existing = [_trace("1", value=0.5)]
+        fresh = [_trace("1", value=0.5)]
+        merged, stats = merge_trace_data(existing, fresh)
+        assert stats["reused"] == 1
+        assert stats["updated"] == 0
+
+
+class TestComputeSummaryScores:
+    def test_numeric_summary(self):
+        traces = [_trace("0", 0.6), _trace("1", 0.8)]
+        summary = compute_summary_scores(traces)
+        assert len(summary) == 1
+        s = summary[0]
+        assert s["name"] == "accuracy"
+        assert s["total_pairs"] == 2
+        assert s["avg"] == 0.7
+
+    def test_categorical_distribution(self):
+        traces = [
+            _trace("0", "CORRECT", name="verdict", data_type="CATEGORICAL"),
+            _trace("1", "CORRECT", name="verdict", data_type="CATEGORICAL"),
+            _trace("2", "WRONG", name="verdict", data_type="CATEGORICAL"),
+        ]
+        summary = compute_summary_scores(traces)
+        s = summary[0]
+        assert s["distribution"] == {"CORRECT": 2, "WRONG": 1}
+        assert s["total_pairs"] == 3
+
+    def test_none_values_excluded(self):
+        traces = [_trace("0", 1.0), _trace("1", None)]
+        summary = compute_summary_scores(traces)
+        assert summary[0]["total_pairs"] == 1
+
+
+class TestMergeScoresStepForward:
+    def test_summary_recomputed_from_union(self):
+        """total_pairs reflects the merged union, not the (smaller) fresh fetch."""
+        cached = {
+            "summary_scores": [],
+            "traces": [_trace(str(i)) for i in range(29)],
+        }
+        fresh = {
+            "summary_scores": [],
+            "traces": [_trace(str(i)) for i in range(27)],
+        }
+        merged, _ = merge_scores_step_forward(cached, fresh)
+        assert len(merged["traces"]) == 29
+        accuracy = next(s for s in merged["summary_scores"] if s["name"] == "accuracy")
+        assert accuracy["total_pairs"] == 29
+
+    def test_summary_only_score_preserved(self):
+        """A summary metric with no per-trace value survives the merge."""
+        cached = {
+            "summary_scores": [{"name": "cosine_similarity", "avg": 0.91}],
+            "traces": [_trace("0")],
+        }
+        fresh = {"summary_scores": [], "traces": [_trace("0")]}
+        merged, _ = merge_scores_step_forward(cached, fresh)
+        names = {s["name"] for s in merged["summary_scores"]}
+        assert "cosine_similarity" in names
+        assert "accuracy" in names
+
+    def test_none_existing_score(self):
+        fresh = {"summary_scores": [], "traces": [_trace("0")]}
+        merged, _ = merge_scores_step_forward(None, fresh)
+        assert len(merged["traces"]) == 1

--- a/backend/app/tests/services/evaluations/test_evaluation_service_s3.py
+++ b/backend/app/tests/services/evaluations/test_evaluation_service_s3.py
@@ -112,7 +112,7 @@ class TestGetEvaluationWithScoresS3:
     @patch("app.services.evaluations.evaluation.get_evaluation_run_by_id")
     @patch("app.services.evaluations.evaluation.load_json_from_object_store")
     @patch("app.services.evaluations.evaluation.get_cloud_storage")
-    def test_resync_bypasses_cache_and_fetches_langfuse(
+    def test_resync_merges_cache_with_langfuse(
         self,
         mock_get_storage: MagicMock,
         mock_load: MagicMock,
@@ -122,7 +122,7 @@ class TestGetEvaluationWithScoresS3:
         mock_save_score: MagicMock,
         eval_run_factory: Callable[..., MagicMock],
     ) -> None:
-        """Verify resync=True skips S3/DB and fetches from Langfuse."""
+        """Verify resync=True re-fetches Langfuse and merges with cached traces."""
         eval_run = eval_run_factory(
             id=100,
             status="completed",
@@ -132,10 +132,13 @@ class TestGetEvaluationWithScoresS3:
             run_name="test_run",
         )
         mock_get_eval.return_value = eval_run
+        mock_get_storage.return_value = MagicMock()
+        # Cache currently holds one trace; Langfuse returns a different one.
+        mock_load.return_value = [{"trace_id": "old", "scores": []}]
         mock_get_langfuse.return_value = MagicMock()
         mock_fetch_langfuse.return_value = {
             "summary_scores": [],
-            "traces": [{"trace_id": "new"}],
+            "traces": [{"trace_id": "new", "scores": []}],
         }
         mock_save_score.return_value = eval_run
 
@@ -148,5 +151,100 @@ class TestGetEvaluationWithScoresS3:
             resync_score=True,
         )
 
-        mock_load.assert_not_called()  # S3 skipped
-        mock_fetch_langfuse.assert_called_once()  # Langfuse called
+        mock_load.assert_called_once()  # cache read so it can be merged
+        mock_fetch_langfuse.assert_called_once()  # Langfuse re-fetched
+
+        # Saved score must be the union of cached + fresh traces (step-forward).
+        saved_score = mock_save_score.call_args.kwargs["score"]
+        saved_ids = {t["trace_id"] for t in saved_score["traces"]}
+        assert saved_ids == {"old", "new"}
+
+    @patch("app.services.evaluations.evaluation.save_score")
+    @patch("app.services.evaluations.evaluation.fetch_trace_scores_from_langfuse")
+    @patch("app.services.evaluations.evaluation.get_langfuse_client")
+    @patch("app.services.evaluations.evaluation.get_evaluation_run_by_id")
+    @patch("app.services.evaluations.evaluation.load_json_from_object_store")
+    @patch("app.services.evaluations.evaluation.get_cloud_storage")
+    def test_resync_never_shrinks_pair_count(
+        self,
+        mock_get_storage: MagicMock,
+        mock_load: MagicMock,
+        mock_get_eval: MagicMock,
+        mock_get_langfuse: MagicMock,
+        mock_fetch_langfuse: MagicMock,
+        mock_save_score: MagicMock,
+        eval_run_factory: Callable[..., MagicMock],
+    ) -> None:
+        """A resync that returns fewer traces must not drop cached ones (29 -> 27 -> 29)."""
+        eval_run = eval_run_factory(
+            id=100,
+            status="completed",
+            score={"summary_scores": []},
+            score_trace_url="s3://bucket/traces.json",
+            dataset_name="test_dataset",
+            run_name="test_run",
+        )
+        mock_get_eval.return_value = eval_run
+        mock_get_storage.return_value = MagicMock()
+        # Cache has 29 traces; a transient Langfuse hiccup only returns 27.
+        mock_load.return_value = [{"trace_id": str(i), "scores": []} for i in range(29)]
+        mock_get_langfuse.return_value = MagicMock()
+        mock_fetch_langfuse.return_value = {
+            "summary_scores": [],
+            "traces": [{"trace_id": str(i), "scores": []} for i in range(27)],
+        }
+        mock_save_score.return_value = eval_run
+
+        get_evaluation_with_scores(
+            session=MagicMock(),
+            evaluation_id=100,
+            organization_id=1,
+            project_id=1,
+            get_trace_info=True,
+            resync_score=True,
+        )
+
+        saved_score = mock_save_score.call_args.kwargs["score"]
+        assert len(saved_score["traces"]) == 29  # stayed at 29, not 27
+
+    @patch("app.services.evaluations.evaluation.save_score")
+    @patch("app.services.evaluations.evaluation.fetch_trace_scores_from_langfuse")
+    @patch("app.services.evaluations.evaluation.get_langfuse_client")
+    @patch("app.services.evaluations.evaluation.get_evaluation_run_by_id")
+    @patch("app.services.evaluations.evaluation.load_json_from_object_store")
+    @patch("app.services.evaluations.evaluation.get_cloud_storage")
+    def test_resync_skipped_when_cache_unreadable(
+        self,
+        mock_get_storage: MagicMock,
+        mock_load: MagicMock,
+        mock_get_eval: MagicMock,
+        mock_get_langfuse: MagicMock,
+        mock_fetch_langfuse: MagicMock,
+        mock_save_score: MagicMock,
+        eval_run_factory: Callable[..., MagicMock],
+    ) -> None:
+        """If the cache pointer exists but cannot be read, resync must not overwrite it."""
+        eval_run = eval_run_factory(
+            id=100,
+            status="completed",
+            score={"summary_scores": []},
+            score_trace_url="s3://bucket/traces.json",
+            dataset_name="test_dataset",
+            run_name="test_run",
+        )
+        mock_get_eval.return_value = eval_run
+        mock_get_storage.return_value = MagicMock()
+        mock_load.side_effect = Exception("S3 unavailable")
+
+        result, error = get_evaluation_with_scores(
+            session=MagicMock(),
+            evaluation_id=100,
+            organization_id=1,
+            project_id=1,
+            get_trace_info=True,
+            resync_score=True,
+        )
+
+        assert error is not None
+        mock_fetch_langfuse.assert_not_called()  # did not re-fetch
+        mock_save_score.assert_not_called()  # did not overwrite the cache

--- a/backend/app/tests/services/evaluations/test_evaluation_service_s3.py
+++ b/backend/app/tests/services/evaluations/test_evaluation_service_s3.py
@@ -165,54 +165,6 @@ class TestGetEvaluationWithScoresS3:
     @patch("app.services.evaluations.evaluation.get_evaluation_run_by_id")
     @patch("app.services.evaluations.evaluation.load_json_from_object_store")
     @patch("app.services.evaluations.evaluation.get_cloud_storage")
-    def test_resync_never_shrinks_pair_count(
-        self,
-        mock_get_storage: MagicMock,
-        mock_load: MagicMock,
-        mock_get_eval: MagicMock,
-        mock_get_langfuse: MagicMock,
-        mock_fetch_langfuse: MagicMock,
-        mock_save_score: MagicMock,
-        eval_run_factory: Callable[..., MagicMock],
-    ) -> None:
-        """A resync that returns fewer traces must not drop cached ones (29 -> 27 -> 29)."""
-        eval_run = eval_run_factory(
-            id=100,
-            status="completed",
-            score={"summary_scores": []},
-            score_trace_url="s3://bucket/traces.json",
-            dataset_name="test_dataset",
-            run_name="test_run",
-        )
-        mock_get_eval.return_value = eval_run
-        mock_get_storage.return_value = MagicMock()
-        # Cache has 29 traces; a transient Langfuse hiccup only returns 27.
-        mock_load.return_value = [{"trace_id": str(i), "scores": []} for i in range(29)]
-        mock_get_langfuse.return_value = MagicMock()
-        mock_fetch_langfuse.return_value = {
-            "summary_scores": [],
-            "traces": [{"trace_id": str(i), "scores": []} for i in range(27)],
-        }
-        mock_save_score.return_value = eval_run
-
-        get_evaluation_with_scores(
-            session=MagicMock(),
-            evaluation_id=100,
-            organization_id=1,
-            project_id=1,
-            get_trace_info=True,
-            resync_score=True,
-        )
-
-        saved_score = mock_save_score.call_args.kwargs["score"]
-        assert len(saved_score["traces"]) == 29  # stayed at 29, not 27
-
-    @patch("app.services.evaluations.evaluation.save_score")
-    @patch("app.services.evaluations.evaluation.fetch_trace_scores_from_langfuse")
-    @patch("app.services.evaluations.evaluation.get_langfuse_client")
-    @patch("app.services.evaluations.evaluation.get_evaluation_run_by_id")
-    @patch("app.services.evaluations.evaluation.load_json_from_object_store")
-    @patch("app.services.evaluations.evaluation.get_cloud_storage")
     def test_resync_skipped_when_cache_unreadable(
         self,
         mock_get_storage: MagicMock,


### PR DESCRIPTION
## Summary

Target issue is #919

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

## Notes

This change makes resync **monotonic**—it only moves forward.

Instead of replacing cached data with the latest fetch, resync now loads the existing cached traces, fetches new traces, and **merges them by `trace_id`**. Traces that exist only in the cache are preserved, new traces are added, and traces found in both sources are merged. When the same score exists in both versions, the freshly fetched value takes precedence.

After merging, summary statistics are recalculated from the combined set of traces so that `total_pairs` and averages remain accurate.

The result is that pair counts can only increase across resyncs (for example, `15/30 → 24/30 → 30/30`). A temporary partial fetch can no longer reduce the count—it simply adds whatever new data is available and leaves the rest unchanged.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced evaluation score synchronization with improved data merging during resync operations

* **Bug Fixes**
  * Improved handling of corrupted cached evaluation data; now returns error instead of overwriting valid cached traces
  * Enhanced warning logging for partial outage scenarios during trace score fetching

* **Tests**
  * Added comprehensive tests for evaluation score merge operations and cache handling scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->