### PR TITLE
Codecov: Upgrade the Codecov Version & Test Cases Updates

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -72,7 +72,7 @@ jobs:
         working-directory: backend
 
       - name: Upload coverage reports to codecov
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/backend/app/crud/evaluations/merge.py
+++ b/backend/app/crud/evaluations/merge.py
@@ -9,6 +9,7 @@ result monotonic, so the pair count can only grow across resyncs (never 29 -> 27
 import itertools
 import logging
 from collections import Counter
+from typing import Any
 
 import numpy as np
 
@@ -80,7 +81,7 @@ def _merge_single_trace(existing: TraceData, fresh: TraceData) -> TraceData:
     for fresh_score in fresh.get("scores", []):
         merged_scores_by_name[fresh_score["name"]] = fresh_score
 
-    return {
+    merged: dict[str, Any] = {
         "trace_id": fresh.get("trace_id") or existing.get("trace_id", ""),
         "question": fresh.get("question") or existing.get("question", ""),
         "llm_answer": fresh.get("llm_answer") or existing.get("llm_answer", ""),
@@ -88,11 +89,15 @@ def _merge_single_trace(existing: TraceData, fresh: TraceData) -> TraceData:
             fresh.get("ground_truth_answer") or existing.get("ground_truth_answer", "")
         ),
         "question_id": fresh.get("question_id") or existing.get("question_id"),
-        "category": (
-            fresh.get("category") or existing.get("category") or DEFAULT_CATEGORY
-        ),
         "scores": list(merged_scores_by_name.values()),
     }
+
+    if "category" in existing or "category" in fresh:
+        merged["category"] = (
+            fresh.get("category") or existing.get("category") or DEFAULT_CATEGORY
+        )
+
+    return merged
 
 
 def _reconcile_trace(

--- a/backend/app/tests/crud/evaluations/test_merge.py
+++ b/backend/app/tests/crud/evaluations/test_merge.py
@@ -81,6 +81,33 @@ class TestMergeTraceData:
         assert stats["reused"] == 1
         assert stats["updated"] == 0
 
+    def test_category_and_external_id_preserved_across_resync(self):
+        def _real(trace_id, value=0.5, category="Health"):
+            return {
+                **_trace(trace_id, value=value),
+                "category": category,
+            }
+
+        # Both sides have the keys → merged carries them.
+        existing = [_real("1", value=0.5, category="Health")]
+        fresh = [_real("1", value=0.9, category="Health")]
+        merged, stats = merge_trace_data(existing, fresh)
+        assert merged[0]["category"] == "Health"
+        assert merged[0]["scores"][0]["value"] == 0.9
+        assert stats["updated"] == 1
+
+        # Existing has them, fresh missing the keys → fall back to existing.
+        existing2 = [_real("2", category="Education")]
+        fresh2 = [_trace("2", value=1.0)]  # legacy-shape trace
+        merged2, _ = merge_trace_data(existing2, fresh2)
+        assert merged2[0]["category"] == "Education"
+
+        # Fresh has them, existing missing the keys → take from fresh.
+        existing3 = [_trace("3")]  # legacy-shape trace
+        fresh3 = [_real("3", category="Sports")]
+        merged3, _ = merge_trace_data(existing3, fresh3)
+        assert merged3[0]["category"] == "Sports"
+
 
 class TestComputeSummaryScores:
     def test_numeric_summary(self):


### PR DESCRIPTION
## Summary
- Added the test cases for the Evals category.
- Upgraded `codecov/codecov-action` from `v6` to `v7` which bumps the wrapper submodule to fetch the PGP key from the new `codecovsecops` Keybase account.

**References:**
   - Bug report: https://github.com/codecov/wrapper/issues/71
   - Fix: https://github.com/codecov/codecov-action/releases/tag/v7.0.0
## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.