### PR TITLE
Release: Update Deployment Script

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -3,7 +3,7 @@ name: Deploy Kaapi to ECS Production
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'  # Deploy only when tags like v1.0.0, v2.1.0, etc., are created
+      - "v[0-9]+.[0-9]+.[0-9]+" # Deploy only when tags like v1.0.0, v2.1.0, etc., are created
 
 jobs:
   build:
@@ -83,4 +83,9 @@ jobs:
           aws ecs update-service \
             --cluster ${{ vars.AWS_RESOURCE_PREFIX }}-cluster \
             --service ${{ vars.AWS_RESOURCE_PREFIX }}-service \
+            --force-new-deployment
+
+          aws ecs update-service \
+            --cluster ${{ vars.AWS_RESOURCE_PREFIX }}-cluster \
+            --service ${{ vars.AWS_RESOURCE_PREFIX }}-celery-task \
             --force-new-deployment


### PR DESCRIPTION
## Summary
Added support for deploying an additional ECS service in the deployment script. We now have two services:
* Backend + Celery Worker
* Dedicated Celery Worker (with higher concurrency)

Both services will now be redeployed whenever new changes are deployed.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release deployment handling so version-tagged releases are recognized more reliably.
  * Updated deployment steps to restart all relevant services during a release, helping changes reach users more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->