### PR TITLE
Document: Add JSON format support

### DIFF
--- a/backend/app/services/doctransform/registry.py
+++ b/backend/app/services/doctransform/registry.py
@@ -38,6 +38,7 @@ EXTENSION_TO_FORMAT: dict[str, str] = {
     ".md": "markdown",
     ".markdown": "markdown",
     ".csv": "csv",
+    ".json": "json",
 }
 
 # Map format names to file extensions
@@ -49,6 +50,7 @@ FORMAT_TO_EXTENSION: dict[str, str] = {
     "text": ".txt",
     "markdown": ".md",
     "csv": ".csv",
+    "json": ".json",
 }
 
 

--- a/backend/app/tests/api/routes/documents/test_route_document_upload.py
+++ b/backend/app/tests/api/routes/documents/test_route_document_upload.py
@@ -73,6 +73,16 @@ def pdf_scratch():
 
 
 @pytest.fixture
+def json_scratch():
+    # Legacy assistants clone .json knowledge-base files
+    with NamedTemporaryFile(mode="w", suffix=".json", delete=False) as fp:
+        fp.write('{"name": "legacy assistant", "instructions": "be helpful"}')
+        fp.flush()
+        yield Path(fp.name)
+        Path(fp.name).unlink()
+
+
+@pytest.fixture
 def route():
     return Route("")
 
@@ -210,6 +220,47 @@ class TestDocumentRouteUpload:
         assert response.success is True
         transformation_job = response.data["transformation_job"]
         assert transformation_job["transformer"] == "zerox"
+
+    def test_upload_json_without_transformation(
+        self,
+        db: Session,
+        route: Route,
+        json_scratch: Path,
+        uploader: WebUploader,
+    ) -> None:
+        """Legacy .json knowledge-base files upload without transformation."""
+        aws = AmazonCloudStorageClient()
+        aws.create()
+
+        response = httpx_to_standard(uploader.put(route, json_scratch))
+
+        assert response.success is True
+        assert response.data["transformation_job"] is None
+
+        doc_id = response.data["id"]
+        statement = select(Document).where(Document.id == doc_id)
+        result = db.exec(statement).one()
+        assert result.fname == str(json_scratch)
+
+    def test_upload_json_with_unsupported_transformation(
+        self,
+        db: Session,
+        route: Route,
+        json_scratch: Path,
+        uploader: WebUploader,
+    ) -> None:
+        """.json has no transformer; requesting a target format is rejected."""
+        aws = AmazonCloudStorageClient()
+        aws.create()
+
+        response = uploader.put(route, json_scratch, target_format="markdown")
+
+        assert response.status_code == 400
+        error_data = response.json()
+        assert (
+            "Transformation from json to markdown is not supported"
+            in error_data["error"]
+        )
 
     def test_upload_with_unsupported_transformation(
         self,

--- a/backend/app/tests/services/doctransformer/test_registry.py
+++ b/backend/app/tests/services/doctransformer/test_registry.py
@@ -32,6 +32,11 @@ def test_get_file_format_valid():
     assert get_file_format("file.docx") == "docx"
     assert get_file_format("file.md") == "markdown"
     assert get_file_format("file.html") == "html"
+    assert get_file_format("file.json") == "json"
+
+
+def test_get_file_format_json_case_insensitive():
+    assert get_file_format("legacy_assistant.JSON") == "json"
 
 
 def test_get_file_format_invalid():


### PR DESCRIPTION
## Issue

Closes #986

## Summary

- Previously Document doesn't support json format upload 
- Added JSON format mapping to `EXTENSION_TO_FORMAT` and `FORMAT_TO_EXTENSION`, so to support `.json` upload in document.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.