### PR TITLE
docs(credentials): Add Anthropic provider support

### DIFF
--- a/backend/app/api/docs/credentials/create.md
+++ b/backend/app/api/docs/credentials/create.md
@@ -3,7 +3,7 @@ Persist new credentials for the current organization and project.
 Credentials are encrypted and stored securely for provider integrations (OpenAI, Langfuse, etc.). Only one credential per provider is allowed per organization-project combination. You can send credentials for a single provider or multiple providers in one request. Refer to the examples below for the required input parameters for each provider.
 
 ### Supported Providers:
-- **LLM:** openai, sarvamai, google(gemini)
+- **LLM:** openai, anthropic, sarvamai, google(gemini)
 - **Observability:** langfuse
 - **Audio:** elevenlabs
 - **Miscellaneous** webhook_secret
@@ -27,6 +27,9 @@ Credentials are encrypted and stored securely for provider integrations (OpenAI,
   "credential": {
     "openai": {
       "api_key": "sk-proj-..."
+    },
+    "anthropic": {
+      "api_key": "sk-ant-..."
     },
     "google": {
       "api_key": "AIzaSy..."


### PR DESCRIPTION
## Issue

Closes #999 

## Summary

- **Before:** Documentation did not include support for the Anthropic provider.
- **Now:** Credentials documentation adds support for the Anthropic provider.
- Updated documentation to reflect the new provider.
- Ensured that examples and usage instructions are clear.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.