### PR TITLE
fix(vertex): Correct host name typo

### DIFF
--- a/backend/app/services/llm/providers/google_ai.py
+++ b/backend/app/services/llm/providers/google_ai.py
@@ -94,7 +94,11 @@ class VertexClient:
         self.gcs_bucket = gcs_bucket or settings.GCS_AUDIO_BUCKET
 
     def endpoint(self, model: str) -> str:
-        host = N
+        host = ""
+        if self.location == "global":
+            host = "aiplatform.googleapis.com"
+        else:
+            host = f"{self.location}-aiplatform.googleapis.com"
         return (
             f"https://{host}/v1"
             f"/projects/{self.project_id}/locations/{self.location}"

--- a/backend/app/services/llm/providers/google_ai.py
+++ b/backend/app/services/llm/providers/google_ai.py
@@ -94,7 +94,6 @@ class VertexClient:
         self.gcs_bucket = gcs_bucket or settings.GCS_AUDIO_BUCKET
 
     def endpoint(self, model: str) -> str:
-        host = ""
         if self.location == "global":
             host = "aiplatform.googleapis.com"
         else:

--- a/backend/app/tests/services/llm/providers/test_google_ai.py
+++ b/backend/app/tests/services/llm/providers/test_google_ai.py
@@ -7,9 +7,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-# ponytail: Vertex provider is temporarily disabled in the registry; skip the
-# whole module until it is re-enabled.
-pytestmark = pytest.mark.skip(
+# ponytail: Vertex provider is temporarily disabled in the registry; skip only
+# the routing/execute tests. Pure client tests (endpoint, sa_info, credential
+# fallback) still run for coverage.
+_vertex_disabled = pytest.mark.skip(
     reason="Vertex provider disabled — routing swapped to GoogleAIProvider"
 )
 
@@ -85,6 +86,7 @@ def _mock_gcs(monkeypatch):
     )
 
 
+@_vertex_disabled
 class TestGoogleVertexAIProvider:
     @pytest.fixture
     def client(self) -> VertexClient:


### PR DESCRIPTION
## Issue Ad-Hoc

## Summary

Fixed typo in host string initialization in vertex client. Now the conditional init for host works fine.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google AI endpoint handling so the global region uses the correct service host, while other regions continue using region-specific hosts.
  * This should make model requests route more reliably across supported locations.
* **Tests**
  * Expanded test coverage so endpoint behavior and related client checks continue running even when some Vertex routing tests are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->